### PR TITLE
feat: add actions to gradlew build

### DIFF
--- a/.github/workflows/release_jar.yaml
+++ b/.github/workflows/release_jar.yaml
@@ -1,0 +1,30 @@
+name: Release burp-mcp-all.jar
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - name: setup java to use gradle
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: build to create burp-mcp-all.jar
+        run: ./gradlew build
+
+      - name: put burp-mcp-all.jar in release package
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/libs/burp-mcp-all.jar


### PR DESCRIPTION
Hello.

Thank you for creating a useful Burp MCP Server.
It's a great help in automating our vulnerability assessment.

---

## Purpose of this pull request

In this pull request, I add `.github/workflows/build_jar.yaml` to automatically run `gradlew build` when release tag create.

---

## Test

In my forked repository, it works correctly.

https://github.com/RyosukeDTomita/mcp-server/releases/tag/test

---

