### PR TITLE
Scope Management Features

### DIFF
--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -163,6 +163,21 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
             }
     }
 
+    mcpPaginatedTool<GetProxyHttpHistoryScope>("Displays all in-scope items within the proxy HTTP history") {
+        api.proxy().history { api.scope().isInScope(it.toString()) }.asSequence()
+            .map {
+                // Limit the size of serialized data to prevent overflow
+                val serialized = Json.encodeToString(it.toSerializableForm())
+                if (serialized.length > 5000) {
+                    // Truncate long responses to prevent chat overflow
+                    val truncated = serialized.substring(0, 5000) + "... (truncated)"
+                    truncated
+                } else {
+                    serialized
+                }
+            }
+    }
+
     mcpPaginatedTool<GetProxyWebsocketHistory>("Displays items within the proxy WebSocket history") {
         api.proxy().webSocketHistory().asSequence()
             .map { 
@@ -226,6 +241,11 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
 
         "Editor text has been set"
     }
+
+    mcpTool<AddTargetToScope>("Adds the specified target to Burp Suite's scope") {
+        api.scope().includeInScope(target)
+        "Target has been added to scope"
+    }
 }
 
 fun getActiveEditor(api: MontoyaApi): JTextArea? {
@@ -272,7 +292,7 @@ data class SendHttp2Request(
 
 @Serializable
 data class CreateRepeaterTab(
-    val tabName: String?,
+    val tabName: String = "",
     val content: String,
     override val targetHostname: String,
     override val targetPort: Int,
@@ -281,7 +301,7 @@ data class CreateRepeaterTab(
 
 @Serializable
 data class SendToIntruder(
-    val tabName: String?,
+    val tabName: String = "",
     val content: String,
     override val targetHostname: String,
     override val targetPort: Int,
@@ -319,6 +339,9 @@ data class SetProxyInterceptState(val intercepting: Boolean)
 data class SetActiveEditorContents(val text: String)
 
 @Serializable
+data class AddTargetToScope(val target: String)
+
+@Serializable
 data class GetScannerIssues(override val count: Int, override val offset: Int) : Paginated
 
 @Serializable
@@ -326,6 +349,9 @@ data class GetProxyHttpHistory(override val count: Int, override val offset: Int
 
 @Serializable
 data class GetProxyHttpHistoryRegex(val regex: String, override val count: Int, override val offset: Int) : Paginated
+
+@Serializable
+data class GetProxyHttpHistoryScope( override val count: Int, override val offset: Int) : Paginated
 
 @Serializable
 data class GetProxyWebsocketHistory(override val count: Int, override val offset: Int) : Paginated


### PR DESCRIPTION
Enhanced Burp Suite MCP Tools with Scope Management Features

This PR introduces improvements to the Burp Suite MCP tools, focusing on scope management and request filtering:

1. Added a new tool `GetProxyHttpHistoryScope` that allows to get history within scope items. 
2. Added a new tool `AddTargetToScope` that allows programmatic addition of targets to Burp Suite's scope. This feature enables automated scope management and integration with other security tools.

Some Bug Fixes: 
Changed the `tabName` parameter from nullable String (`String?`) to non-nullable with default empty string value (`String = ""`). This change was made to address compatibility issues with OpenAI's handling of nullable types in the MCP protocol.
