### PR TITLE
Add a Checkbox to filter password field for output_project_options and output_user_options.

### DIFF
--- a/src/main/kotlin/net/portswigger/mcp/config/McpConfig.kt
+++ b/src/main/kotlin/net/portswigger/mcp/config/McpConfig.kt
@@ -48,6 +48,8 @@ class McpConfig(storage: PersistedObject, private val logging: Logging) {
             }
         }
 
+    var filterConfigCredentials by storage.boolean(true)
+
     private var _autoApproveTargets by storage.stringList("")
     private val targetsChangeListeners = CopyOnWriteArrayList<ListenerRegistration>()
     private val dataAccessChangeListeners = CopyOnWriteArrayList<ListenerRegistration>()

--- a/src/main/kotlin/net/portswigger/mcp/config/components/ServerConfigurationPanel.kt
+++ b/src/main/kotlin/net/portswigger/mcp/config/components/ServerConfigurationPanel.kt
@@ -86,6 +86,14 @@ class ServerConfigurationPanel(
             config.requireDataAccessApproval
         ) { config.alwaysAllowOrganizer = it }
         add(alwaysAllowOrganizerCheckBox)
+        add(createVerticalStrut(Design.Spacing.MD))
+
+        val filterConfigCredentialsCheckBox = createCheckBoxWithSubtitle(
+            "Filter config credentials",
+            "Hides sensitive data in config files (Platform Authentication, socks proxy, etc.)",
+            config.filterConfigCredentials
+        ) { config.filterConfigCredentials = it }
+        add(filterConfigCredentialsCheckBox)
 
         add(validationErrorLabel)
     }

--- a/src/main/kotlin/net/portswigger/mcp/security/SecurityUtils.kt
+++ b/src/main/kotlin/net/portswigger/mcp/security/SecurityUtils.kt
@@ -1,6 +1,80 @@
 package net.portswigger.mcp.security
 
 import java.awt.Frame
+import net.portswigger.mcp.config.McpConfig
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.*
+
+@Serializable
+data class UserOptionsWrapper (
+    var user_options: UserOptions
+)
+
+@Serializable
+data class UserOptions (
+    var bchecks: JsonObject,
+    var connections: Connections,
+    var display: JsonObject,
+    var extender: JsonObject,
+    var intruder: JsonObject,
+    var misc: JsonObject,
+    var proxy: JsonObject,
+    var repeater: JsonObject,
+    var ssl: JsonObject
+)
+
+@Serializable
+data class ProjectOptionsWrapper (
+    var bambda: JsonObject,
+    var logger: JsonObject,
+    var organiser: JsonObject,
+    var project_options: ProjectOptions,
+    var proxy: JsonObject,
+    var repeater: JsonObject,
+    var sequencer: JsonObject,
+    var target: JsonObject
+)
+
+@Serializable
+data class ProjectOptions (
+    var connections: ProjectConnections,
+    var dns: JsonObject,
+    var http: JsonObject,
+    var misc: JsonObject,
+    var sessions: JsonObject,
+    var ssl: JsonObject
+)
+
+@Serializable
+data class Connections (
+    var platform_authentication: PlatformAuth,
+    var socks_proxy: JsonObject,
+    var upstream_proxy: JsonObject
+)
+
+@Serializable
+data class ProjectConnections (
+    var out_of_scope_requests: JsonObject,
+    var platform_authentication: ProjectPlatformAuth,
+    var socks_proxy: JsonObject,
+    var timeouts: JsonObject,
+    var upstream_proxy: JsonObject
+)
+
+@Serializable
+data class PlatformAuth (
+    var credentials: JsonArray,
+    var do_platform_authentication: Boolean,
+    var prompt_on_authentication_failure: Boolean
+)
+
+@Serializable
+data class ProjectPlatformAuth (
+    var credentials: JsonArray,
+    var do_platform_authentication: Boolean,
+    var prompt_on_authentication_failure: Boolean,
+    var use_user_options: Boolean
+)
 
 /**
  * Finds the Burp Suite main frame or the largest available frame as fallback
@@ -17,4 +91,65 @@ fun findBurpFrame(): Frame? {
     } ?: Frame.getFrames()
         .filter { it.isVisible && it.isDisplayable }
         .maxByOrNull { it.width * it.height }
+}
+
+fun filterUserConfigCredentials(jsonString: String): String {
+    try {
+        val userOptionWrapper = Json.decodeFromString<UserOptionsWrapper>(jsonString)
+        val userOptions = userOptionWrapper.user_options
+
+        val connections = userOptions.connections
+        val credentials = connections.platform_authentication.credentials
+        val socks_proxy = connections.socks_proxy
+
+        connections.platform_authentication.credentials = filterPlatformAuth(credentials)   
+        connections.socks_proxy = filterSocksProxy(socks_proxy) as JsonObject
+
+        return Json.encodeToString(userOptionWrapper)
+    } catch (e: Exception) {
+        throw RuntimeException("Failed to filter user config credentials", e)
+    }
+}
+
+fun filterProjectConfigCredentials(jsonString: String): String {
+    try {
+        val projectOptionsWrapper = Json.decodeFromString<ProjectOptionsWrapper>(jsonString)
+        val options = projectOptionsWrapper.project_options
+
+        val connections = options.connections
+        val credentials = connections.platform_authentication.credentials
+        val socks_proxy = connections.socks_proxy
+        connections.platform_authentication.credentials = filterPlatformAuth(credentials)
+        connections.socks_proxy = filterSocksProxy(socks_proxy) as JsonObject
+
+        return Json.encodeToString(projectOptionsWrapper)
+    } catch (e: Exception) {
+        throw RuntimeException("Failed to filter project config credentials", e)
+    }
+}
+
+private fun filterPlatformAuth(array: JsonArray): JsonArray {
+    return JsonArray(array.map { element -> 
+        val credentialObj = element.jsonObject
+        JsonObject(
+            credentialObj.mapValues { (key, value) ->
+                when (key) {
+                    "password" -> JsonPrimitive("*****")
+                    else -> value
+                }
+            }
+        )
+    })
+}
+
+private fun filterSocksProxy(value: JsonElement): JsonElement {
+    val obj = value.jsonObject
+    return JsonObject(
+        obj.mapValues { (key, value) ->
+            when (key) {
+                "password" -> JsonPrimitive("*****")
+                else -> value
+            }
+        }
+    )
 }

--- a/src/main/kotlin/net/portswigger/mcp/security/SecurityUtils.kt
+++ b/src/main/kotlin/net/portswigger/mcp/security/SecurityUtils.kt
@@ -6,74 +6,8 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
 
 @Serializable
-data class UserOptionsWrapper (
-    var user_options: UserOptions
-)
-
-@Serializable
-data class UserOptions (
-    var bchecks: JsonObject,
-    var connections: Connections,
-    var display: JsonObject,
-    var extender: JsonObject,
-    var intruder: JsonObject,
-    var misc: JsonObject,
-    var proxy: JsonObject,
-    var repeater: JsonObject,
-    var ssl: JsonObject
-)
-
-@Serializable
-data class ProjectOptionsWrapper (
-    var bambda: JsonObject,
-    var logger: JsonObject,
-    var organiser: JsonObject,
-    var project_options: ProjectOptions,
-    var proxy: JsonObject,
-    var repeater: JsonObject,
-    var sequencer: JsonObject,
-    var target: JsonObject
-)
-
-@Serializable
-data class ProjectOptions (
-    var connections: ProjectConnections,
-    var dns: JsonObject,
-    var http: JsonObject,
-    var misc: JsonObject,
-    var sessions: JsonObject,
-    var ssl: JsonObject
-)
-
-@Serializable
-data class Connections (
-    var platform_authentication: PlatformAuth,
-    var socks_proxy: JsonObject,
-    var upstream_proxy: JsonObject
-)
-
-@Serializable
-data class ProjectConnections (
-    var out_of_scope_requests: JsonObject,
-    var platform_authentication: ProjectPlatformAuth,
-    var socks_proxy: JsonObject,
-    var timeouts: JsonObject,
-    var upstream_proxy: JsonObject
-)
-
-@Serializable
-data class PlatformAuth (
-    var credentials: JsonArray,
-    var do_platform_authentication: Boolean,
-    var prompt_on_authentication_failure: Boolean
-)
-
-@Serializable
-data class ProjectPlatformAuth (
-    var credentials: JsonArray,
-    var do_platform_authentication: Boolean,
-    var prompt_on_authentication_failure: Boolean,
-    var use_user_options: Boolean
+data class SecurityConfig(
+    val options: Map<String, Map<String, JsonElement>>
 )
 
 /**
@@ -93,63 +27,36 @@ fun findBurpFrame(): Frame? {
         .maxByOrNull { it.width * it.height }
 }
 
-fun filterUserConfigCredentials(jsonString: String): String {
-    try {
-        val userOptionWrapper = Json.decodeFromString<UserOptionsWrapper>(jsonString)
-        val userOptions = userOptionWrapper.user_options
-
-        val connections = userOptions.connections
-        val credentials = connections.platform_authentication.credentials
-        val socks_proxy = connections.socks_proxy
-
-        connections.platform_authentication.credentials = filterPlatformAuth(credentials)   
-        connections.socks_proxy = filterSocksProxy(socks_proxy) as JsonObject
-
-        return Json.encodeToString(userOptionWrapper)
+fun filterConfigCredentials(json: String): String {
+    return try {
+        val jsonElement = Json.parseToJsonElement(json)
+        val filteredElement = filterJsonElement(jsonElement)
+        Json.encodeToString(filteredElement)
     } catch (e: Exception) {
-        throw RuntimeException("Failed to filter user config credentials", e)
+        throw RuntimeException("Failed to filter credentials", e)
     }
 }
 
-fun filterProjectConfigCredentials(jsonString: String): String {
-    try {
-        val projectOptionsWrapper = Json.decodeFromString<ProjectOptionsWrapper>(jsonString)
-        val options = projectOptionsWrapper.project_options
-
-        val connections = options.connections
-        val credentials = connections.platform_authentication.credentials
-        val socks_proxy = connections.socks_proxy
-        connections.platform_authentication.credentials = filterPlatformAuth(credentials)
-        connections.socks_proxy = filterSocksProxy(socks_proxy) as JsonObject
-
-        return Json.encodeToString(projectOptionsWrapper)
-    } catch (e: Exception) {
-        throw RuntimeException("Failed to filter project config credentials", e)
+private fun filterJsonElement(element: JsonElement): JsonElement {
+    return when (element) {
+        is JsonObject -> filterJsonObject(element)
+        is JsonArray -> filterJsonArray(element)
+        else -> element
     }
 }
 
-private fun filterPlatformAuth(array: JsonArray): JsonArray {
-    return JsonArray(array.map { element -> 
-        val credentialObj = element.jsonObject
-        JsonObject(
-            credentialObj.mapValues { (key, value) ->
-                when (key) {
-                    "password" -> JsonPrimitive("*****")
-                    else -> value
-                }
-            }
-        )
-    })
-}
-
-private fun filterSocksProxy(value: JsonElement): JsonElement {
-    val obj = value.jsonObject
-    return JsonObject(
-        obj.mapValues { (key, value) ->
-            when (key) {
-                "password" -> JsonPrimitive("*****")
-                else -> value
-            }
+private fun filterJsonObject(obj: JsonObject): JsonObject {
+    val filteredMap = obj.mapValues { (key, value) ->
+        when {
+            value is JsonPrimitive && value.isString && key == "password" -> 
+                JsonPrimitive("*****")
+            else -> filterJsonElement(value)
         }
-    )
+    }
+    return JsonObject(filteredMap)
+}
+
+private fun filterJsonArray(array: JsonArray): JsonArray {
+    val filteredList = array.map { element -> filterJsonElement(element) }
+    return JsonArray(filteredList)
 }

--- a/src/main/kotlin/net/portswigger/mcp/security/SecurityUtils.kt
+++ b/src/main/kotlin/net/portswigger/mcp/security/SecurityUtils.kt
@@ -1,14 +1,11 @@
 package net.portswigger.mcp.security
 
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import java.awt.Frame
-import net.portswigger.mcp.config.McpConfig
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.*
-
-@Serializable
-data class SecurityConfig(
-    val options: Map<String, Map<String, JsonElement>>
-)
 
 /**
  * Finds the Burp Suite main frame or the largest available frame as fallback

--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -212,7 +212,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
         "Outputs current project-level configuration in JSON format. You can use this to determine the schema for available config options."
     ) {
         val json = api.burpSuite().exportProjectOptionsAsJson()
-        if (config.filterConfigCredentials == true) {
+        if (config.filterConfigCredentials) {
             filterConfigCredentials(json)
         } else {
             json
@@ -224,7 +224,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
         "Outputs current user-level configuration in JSON format. You can use this to determine the schema for available config options."
     ) {
         val json = api.burpSuite().exportUserOptionsAsJson()
-        if (config.filterConfigCredentials == true) {
+        if (config.filterConfigCredentials) {
             filterConfigCredentials(json)
         } else {
             json

--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -18,6 +18,8 @@ import net.portswigger.mcp.schema.toSerializableForm
 import net.portswigger.mcp.security.DataAccessSecurity
 import net.portswigger.mcp.security.DataAccessType
 import net.portswigger.mcp.security.HttpRequestSecurity
+import net.portswigger.mcp.security.filterUserConfigCredentials
+import net.portswigger.mcp.security.filterProjectConfigCredentials
 import java.awt.KeyboardFocusManager
 import java.util.regex.Pattern
 import javax.swing.JTextArea
@@ -210,14 +212,24 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
         "output_project_options",
         "Outputs current project-level configuration in JSON format. You can use this to determine the schema for available config options."
     ) {
-        api.burpSuite().exportProjectOptionsAsJson()
+        val json = api.burpSuite().exportProjectOptionsAsJson()
+        if (config.filterConfigCredentials == true) {
+            filterProjectConfigCredentials(json)
+        } else {
+            json
+        }
     }
 
     mcpTool(
         "output_user_options",
         "Outputs current user-level configuration in JSON format. You can use this to determine the schema for available config options."
     ) {
-        api.burpSuite().exportUserOptionsAsJson()
+        val json = api.burpSuite().exportUserOptionsAsJson()
+        if (config.filterConfigCredentials == true) {
+            filterUserConfigCredentials(json)
+        } else {
+            json
+        }
     }
 
     val toolingDisabledMessage =

--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -18,8 +18,7 @@ import net.portswigger.mcp.schema.toSerializableForm
 import net.portswigger.mcp.security.DataAccessSecurity
 import net.portswigger.mcp.security.DataAccessType
 import net.portswigger.mcp.security.HttpRequestSecurity
-import net.portswigger.mcp.security.filterUserConfigCredentials
-import net.portswigger.mcp.security.filterProjectConfigCredentials
+import net.portswigger.mcp.security.filterConfigCredentials
 import java.awt.KeyboardFocusManager
 import java.util.regex.Pattern
 import javax.swing.JTextArea
@@ -214,7 +213,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
     ) {
         val json = api.burpSuite().exportProjectOptionsAsJson()
         if (config.filterConfigCredentials == true) {
-            filterProjectConfigCredentials(json)
+            filterConfigCredentials(json)
         } else {
             json
         }
@@ -226,7 +225,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
     ) {
         val json = api.burpSuite().exportUserOptionsAsJson()
         if (config.filterConfigCredentials == true) {
-            filterUserConfigCredentials(json)
+            filterConfigCredentials(json)
         } else {
             json
         }

--- a/src/test/kotlin/net/portswigger/mcp/security/CredentialFilterTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/security/CredentialFilterTest.kt
@@ -11,12 +11,10 @@ import io.mockk.mockk
 import io.mockk.every
 import kotlinx.serialization.json.*
 
-class ConfigSecurityFilterTest {
+class CredentialFilterTest {
 
     private lateinit var config: McpConfig
     private lateinit var api: MontoyaApi
-    private lateinit var projectOptions: JsonElement
-    private lateinit var usersOptions: JsonElement
     private lateinit var mockLogging: Logging
     private lateinit var persistedObject: PersistedObject
     private lateinit var projectOptionString: String

--- a/src/test/kotlin/net/portswigger/mcp/security/CredentialFilterTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/security/CredentialFilterTest.kt
@@ -1,0 +1,363 @@
+package net.portswigger.mcp.security
+
+import burp.api.montoya.MontoyaApi
+import burp.api.montoya.persistence.PersistedObject
+import burp.api.montoya.logging.Logging
+import net.portswigger.mcp.config.McpConfig
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.BeforeEach
+import io.mockk.mockk
+import io.mockk.every
+import kotlinx.serialization.json.*
+
+class ConfigSecurityFilterTest {
+
+    private lateinit var config: McpConfig
+    private lateinit var api: MontoyaApi
+    private lateinit var projectOptions: JsonElement
+    private lateinit var usersOptions: JsonElement
+    private lateinit var mockLogging: Logging
+    private lateinit var persistedObject: PersistedObject
+    private lateinit var projectOptionString: String
+    private lateinit var usersOptionString: String
+
+    @BeforeEach
+    fun setUp() {
+        api = mockk<MontoyaApi>()
+        mockLogging = mockk<Logging>()
+        persistedObject = mockk<PersistedObject>()
+        val storage = mutableMapOf<String, Any>(
+            "enabled" to true,
+            "configEditingTooling" to false,
+            "requireHttpRequestApproval" to true,
+            "host" to "127.0.0.1",
+            "_autoApproveTargets" to "",
+            "port" to 9876
+        )
+
+        persistedObject = mockk<PersistedObject>().apply {
+            every { getBoolean(any()) } answers { storage[firstArg()] as? Boolean ?: false }
+            every { getString(any()) } answers { storage[firstArg()] as? String ?: "" }
+            every { getInteger(any()) } answers { storage[firstArg()] as? Int ?: 0 }
+            every { setBoolean(any(), any()) } answers {
+                storage[firstArg()] = secondArg<Boolean>()
+            }
+            every { setString(any(), any()) } answers {
+                storage[firstArg()] = secondArg<String>()
+            }
+            every { setInteger(any(), any()) } answers {
+                storage[firstArg()] = secondArg<Int>()
+            }
+        }
+
+        mockLogging = mockk<Logging>().apply {
+            every { logToError(any<String>()) } returns Unit
+        }
+
+        this.get_user_options_with_customizable_field()
+        this.get_project_options_with_customizable_field()
+        config = McpConfig(persistedObject, mockLogging)
+    }
+
+    fun get_user_options_with_customizable_field(username: String = "", password: String = ""): String {
+        this.usersOptionString = """
+        {
+            "user_options": {
+                "bchecks": {},
+                "connections": {
+                    "platform_authentication": {
+                        "credentials": [
+                            {
+                                "username": "$username",
+                                "password": "$password"
+                            }
+                        ],
+                        "do_platform_authentication": false,
+                        "prompt_on_authentication_failure": false
+                    },
+                    "socks_proxy": {
+                        "username": "$username",
+                        "password": "$password"
+                    },
+                    "upstream_proxy": {
+                        "servers": []
+                    }
+                },
+                "display": {},
+                "extender": {},
+                "intruder": {},
+                "misc": {},
+                "proxy": {},
+                "repeater": {},
+                "ssl": {}
+            }
+        }
+        """.trimIndent()
+        return this.usersOptionString
+    }
+
+    fun get_project_options_with_customizable_field(username: String = "", password: String = ""): String {
+        this.projectOptionString = """
+        {
+            "bambda": {},
+            "logger": {},
+            "organiser": {},
+            "project_options": {
+                "connections": {
+                    "out_of_scope_requests": {},
+                    "platform_authentication": {
+                        "credentials": [
+                            {
+                                "username": "$username",
+                                "password": "$password"
+                            }
+                        ],
+                        "do_platform_authentication": false,
+                        "prompt_on_authentication_failure": false,
+                        "use_user_options": true
+                    },
+                    "socks_proxy": {
+                        "username": "$username",
+                        "password": "$password"
+                    },
+                    "timeouts": {
+                        "connect_timeout": 5000,
+                        "read_timeout": 5000
+                    },
+                    "upstream_proxy": {
+                        "servers": [],
+                        "use_user_options": true
+                    }
+                },
+                "dns": {},
+                "http": {},
+                "misc": {},
+                "sessions": {},
+                "ssl": {}
+            },
+            "proxy": {},
+            "repeater": {},
+            "sequencer": {},
+            "target": {}
+        }
+        """.trimIndent()
+       return this.projectOptionString
+    }
+
+    @Test
+    fun `test security filter on project_options `() {
+        config.filterConfigCredentials = true
+        projectOptionString = get_project_options_with_customizable_field("testuser", "testpass")
+        val filteredProjectJson = filterProjectConfigCredentials(projectOptionString)
+        val parsedJson = Json.parseToJsonElement(filteredProjectJson).jsonObject
+
+        val credentials = parsedJson["project_options"]?.jsonObject
+            ?.get("connections")?.jsonObject
+            ?.get("platform_authentication")?.jsonObject
+            ?.get("credentials")?.jsonArray
+
+        val socks_proxy = parsedJson["project_options"]?.jsonObject
+            ?.get("connections")?.jsonObject
+            ?.get("socks_proxy")?.jsonObject
+
+        credentials?.forEach { credential ->
+            val credentialObj = credential.jsonObject
+            Assertions.assertEquals("*****", credentialObj["password"]?.jsonPrimitive?.content)
+        }
+
+        socks_proxy?.let {
+            Assertions.assertEquals("*****", socks_proxy["password"]?.jsonPrimitive?.content)
+        }
+    }
+
+    @Test
+    fun `test security filter on user_options`() {
+        config.filterConfigCredentials = true
+        usersOptionString = get_user_options_with_customizable_field("testuser", "testpass")
+        val filteredUserJson = filterUserConfigCredentials(usersOptionString)
+        val parsedJson = Json.parseToJsonElement(filteredUserJson).jsonObject
+
+        val credentials = parsedJson["user_options"]?.jsonObject
+            ?.get("connections")?.jsonObject
+            ?.get("platform_authentication")?.jsonObject
+            ?.get("credentials")?.jsonArray
+
+        val socks_proxy = parsedJson["user_options"]?.jsonObject
+            ?.get("connections")?.jsonObject
+            ?.get("socks_proxy")?.jsonObject
+
+        credentials?.forEach { credential ->
+            val credentialObj = credential.jsonObject
+            Assertions.assertEquals("*****", credentialObj["password"]?.jsonPrimitive?.content)
+        }
+
+        socks_proxy?.let {
+            Assertions.assertEquals("*****", it["password"]?.jsonPrimitive?.content)
+        }
+    }
+
+    @Test
+    fun `test security filter with empty credentials on user_options`() {
+        config.filterConfigCredentials = true
+        val empty_user_credentials: String = get_user_options_with_customizable_field("", "")
+        val filteredJson = filterUserConfigCredentials(empty_user_credentials)
+        val parsedJson = Json.parseToJsonElement(filteredJson).jsonObject
+
+        val credentials = parsedJson["user_options"]?.jsonObject
+            ?.get("connections")?.jsonObject
+            ?.get("platform_authentication")?.jsonObject
+            ?.get("credentials")?.jsonArray
+
+        val socks_proxy = parsedJson["user_options"]?.jsonObject
+            ?.get("connections")?.jsonObject
+            ?.get("socks_proxy")?.jsonObject
+
+        credentials?.forEach { credential ->
+            val credentialObj = credential.jsonObject
+            Assertions.assertTrue(credentialObj["username"]?.jsonPrimitive?.content.isNullOrEmpty())
+            Assertions.assertEquals("*****", credentialObj["password"]?.jsonPrimitive?.content)
+        }
+        socks_proxy?.let {
+            Assertions.assertTrue(socks_proxy["username"]?.jsonPrimitive?.content.isNullOrEmpty())
+            Assertions.assertEquals("*****", socks_proxy["password"]?.jsonPrimitive?.content)
+        }
+    }
+
+    @Test
+    fun `test security filter with empty credentials on project_options`() {
+        config.filterConfigCredentials = true
+        val empty_project_credentials = get_project_options_with_customizable_field("", "")
+        val filteredJson = filterProjectConfigCredentials(empty_project_credentials)
+        val parsedJson = Json.parseToJsonElement(filteredJson).jsonObject
+
+        val credentials = parsedJson["project_options"]?.jsonObject
+            ?.get("connections")?.jsonObject
+            ?.get("platform_authentication")?.jsonObject
+            ?.get("credentials")?.jsonArray
+
+        val socks_proxy = parsedJson["project_options"]?.jsonObject
+            ?.get("connections")?.jsonObject
+            ?.get("socks_proxy")?.jsonObject
+
+        credentials?.forEach { credential ->
+            val credentialObj = credential.jsonObject
+            Assertions.assertTrue(credentialObj["username"]?.jsonPrimitive?.content.isNullOrEmpty())
+            Assertions.assertEquals("*****", credentialObj["password"]?.jsonPrimitive?.content)
+        }
+        socks_proxy?.let {
+            Assertions.assertTrue(socks_proxy["username"]?.jsonPrimitive?.content.isNullOrEmpty())
+            Assertions.assertEquals("*****", socks_proxy["password"]?.jsonPrimitive?.content)
+        }
+    }
+
+    @Test
+    fun `test security filter with malformed Json on user_options`() {
+        config.filterConfigCredentials = true
+        val malformedJson = """
+        {
+            "user_options": {
+                "bchecks": {},
+                "connections": {
+                    "platform_authentication": {
+                        "credentials": []
+                    },
+                    "socks_proxy": { "password": "" 
+                },
+                "display": {},
+                "extender": {},
+                "intruder": {},
+                "misc": {},
+                "proxy": {},
+                "repeater": {},
+                "ssl": {}
+            }
+        }
+        """.trimIndent()
+        val exception = Assertions.assertThrows(RuntimeException::class.java) {
+            filterUserConfigCredentials(malformedJson)
+        }
+        Assertions.assertEquals("Failed to filter user config credentials", exception.message)
+        Assertions.assertNotNull(exception.cause)
+    }
+
+    @Test
+    fun `test security filter with malformed Json on project_options`() {
+        config.filterConfigCredentials = true
+        val malformedJson = """
+        {
+            "bambda": {},
+            "logger": {},
+            "organiser": {},
+            "project_options": {
+                "connections": {
+                    "platform_authentication": {
+                        "credentials": []
+                    },
+                    "socks_proxy": { "password": "" }
+                }
+            },
+            "proxy": {},
+            "repeater": {},
+            "sequencer": {},
+            "target": {}
+        
+        """.trimIndent()
+        val exception = Assertions.assertThrows(RuntimeException::class.java) {
+            filterProjectConfigCredentials(malformedJson)
+        }
+        Assertions.assertEquals("Failed to filter project config credentials", exception.message)
+        Assertions.assertNotNull(exception.cause)
+    }
+
+    @Test
+    fun `test security filter with username but no password on user_options`() {
+        config.filterConfigCredentials = true
+        val jsonWithUsernameOnly = get_user_options_with_customizable_field("testuser", "")
+        val filteredJson = filterUserConfigCredentials(jsonWithUsernameOnly)
+        val parsedJson = Json.parseToJsonElement(filteredJson).jsonObject
+
+        val credentials = parsedJson["user_options"]?.jsonObject
+            ?.get("connections")?.jsonObject
+            ?.get("platform_authentication")?.jsonObject
+            ?.get("credentials")?.jsonArray
+
+        val socks_proxy = parsedJson["user_options"]?.jsonObject
+            ?.get("connections")?.jsonObject
+            ?.get("socks_proxy")?.jsonObject
+
+        credentials?.forEach { credential ->
+            val credentialObj = credential.jsonObject
+            Assertions.assertEquals("*****", credentialObj["password"]?.jsonPrimitive?.content)
+        }
+
+        socks_proxy?.let {
+            Assertions.assertEquals("*****", socks_proxy["password"]?.jsonPrimitive?.content)
+        }
+    }
+
+    @Test
+    fun `test security filter with username but no password on project_options`() {
+        config.filterConfigCredentials = true
+        val jsonWithUsernameOnly = get_project_options_with_customizable_field("testuser", "")
+        val filteredJson = filterProjectConfigCredentials(jsonWithUsernameOnly)
+        val parsedJson = Json.parseToJsonElement(filteredJson).jsonObject
+
+        val credentials = parsedJson["project_options"]?.jsonObject
+            ?.get("connections")?.jsonObject
+            ?.get("platform_authentication")?.jsonObject
+            ?.get("credentials")?.jsonArray
+
+        val socks_proxy = parsedJson["project_options"]?.jsonObject
+            ?.get("connections")?.jsonObject
+            ?.get("socks_proxy")?.jsonObject
+
+        credentials?.forEach { credential ->
+            val credentialObj = credential.jsonObject
+            Assertions.assertEquals("*****", credentialObj["password"]?.jsonPrimitive?.content)
+        }
+        socks_proxy?.let {
+            Assertions.assertEquals("*****", socks_proxy["password"]?.jsonPrimitive?.content)
+        }
+    }
+}

--- a/src/test/kotlin/net/portswigger/mcp/security/CredentialFilterTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/security/CredentialFilterTest.kt
@@ -149,7 +149,7 @@ class ConfigSecurityFilterTest {
     fun `test security filter on project_options `() {
         config.filterConfigCredentials = true
         projectOptionString = get_project_options_with_customizable_field("testuser", "testpass")
-        val filteredProjectJson = filterProjectConfigCredentials(projectOptionString)
+        val filteredProjectJson = filterConfigCredentials(projectOptionString)
         val parsedJson = Json.parseToJsonElement(filteredProjectJson).jsonObject
 
         val credentials = parsedJson["project_options"]?.jsonObject
@@ -175,7 +175,7 @@ class ConfigSecurityFilterTest {
     fun `test security filter on user_options`() {
         config.filterConfigCredentials = true
         usersOptionString = get_user_options_with_customizable_field("testuser", "testpass")
-        val filteredUserJson = filterUserConfigCredentials(usersOptionString)
+        val filteredUserJson = filterConfigCredentials(usersOptionString)
         val parsedJson = Json.parseToJsonElement(filteredUserJson).jsonObject
 
         val credentials = parsedJson["user_options"]?.jsonObject
@@ -201,7 +201,7 @@ class ConfigSecurityFilterTest {
     fun `test security filter with empty credentials on user_options`() {
         config.filterConfigCredentials = true
         val empty_user_credentials: String = get_user_options_with_customizable_field("", "")
-        val filteredJson = filterUserConfigCredentials(empty_user_credentials)
+        val filteredJson = filterConfigCredentials(empty_user_credentials)
         val parsedJson = Json.parseToJsonElement(filteredJson).jsonObject
 
         val credentials = parsedJson["user_options"]?.jsonObject
@@ -228,7 +228,7 @@ class ConfigSecurityFilterTest {
     fun `test security filter with empty credentials on project_options`() {
         config.filterConfigCredentials = true
         val empty_project_credentials = get_project_options_with_customizable_field("", "")
-        val filteredJson = filterProjectConfigCredentials(empty_project_credentials)
+        val filteredJson = filterConfigCredentials(empty_project_credentials)
         val parsedJson = Json.parseToJsonElement(filteredJson).jsonObject
 
         val credentials = parsedJson["project_options"]?.jsonObject
@@ -275,9 +275,9 @@ class ConfigSecurityFilterTest {
         }
         """.trimIndent()
         val exception = Assertions.assertThrows(RuntimeException::class.java) {
-            filterUserConfigCredentials(malformedJson)
+            filterConfigCredentials(malformedJson)
         }
-        Assertions.assertEquals("Failed to filter user config credentials", exception.message)
+        Assertions.assertEquals("Failed to filter credentials", exception.message)
         Assertions.assertNotNull(exception.cause)
     }
 
@@ -304,9 +304,9 @@ class ConfigSecurityFilterTest {
         
         """.trimIndent()
         val exception = Assertions.assertThrows(RuntimeException::class.java) {
-            filterProjectConfigCredentials(malformedJson)
+            filterConfigCredentials(malformedJson)
         }
-        Assertions.assertEquals("Failed to filter project config credentials", exception.message)
+        Assertions.assertEquals("Failed to filter credentials", exception.message)
         Assertions.assertNotNull(exception.cause)
     }
 
@@ -314,7 +314,7 @@ class ConfigSecurityFilterTest {
     fun `test security filter with username but no password on user_options`() {
         config.filterConfigCredentials = true
         val jsonWithUsernameOnly = get_user_options_with_customizable_field("testuser", "")
-        val filteredJson = filterUserConfigCredentials(jsonWithUsernameOnly)
+        val filteredJson = filterConfigCredentials(jsonWithUsernameOnly)
         val parsedJson = Json.parseToJsonElement(filteredJson).jsonObject
 
         val credentials = parsedJson["user_options"]?.jsonObject
@@ -340,7 +340,7 @@ class ConfigSecurityFilterTest {
     fun `test security filter with username but no password on project_options`() {
         config.filterConfigCredentials = true
         val jsonWithUsernameOnly = get_project_options_with_customizable_field("testuser", "")
-        val filteredJson = filterProjectConfigCredentials(jsonWithUsernameOnly)
+        val filteredJson = filterConfigCredentials(jsonWithUsernameOnly)
         val parsedJson = Json.parseToJsonElement(filteredJson).jsonObject
 
         val credentials = parsedJson["project_options"]?.jsonObject


### PR DESCRIPTION
This pull request fixes functions that leak the credentials setting of the Platform Authentication and socks proxy. The issue was reported in #22.

## changes:
- Added Checkbox in the Burpsuite MCP UI to enable the filter.
- When the filter is on, the password fields in Platform Authentication and socks proxy is changed to "*****".
- Added unit tests in 'src/test/kotlin/net/portswigger/mcp/security/CredentialFilterTest.kt'.

please review and let me know if there are any issues or improvements needed.