### PR TITLE
Add field selection, enhanced search, and markdown output for MCP tools

### DIFF
--- a/src/main/kotlin/net/portswigger/mcp/config/McpConfig.kt
+++ b/src/main/kotlin/net/portswigger/mcp/config/McpConfig.kt
@@ -15,6 +15,10 @@ class McpConfig(storage: PersistedObject, private val logging: Logging) {
     var port by storage.int(9876)
     var requireHttpRequestApproval by storage.boolean(true)
     var requireHistoryAccessApproval by storage.boolean(true)
+    
+    // AI-optimized MCP server configuration options
+    var excerptLengthLimit by storage.int(200)
+    var maxFieldExtractionSize by storage.int(5000)
 
     private var _alwaysAllowHttpHistory by storage.boolean(false)
     var alwaysAllowHttpHistory: Boolean

--- a/src/main/kotlin/net/portswigger/mcp/schema/JsonSchema.kt
+++ b/src/main/kotlin/net/portswigger/mcp/schema/JsonSchema.kt
@@ -21,7 +21,7 @@ fun getJsonSchemaForProperty(kType: kotlin.reflect.KType): JsonElement {
         Boolean::class ->
             JsonObject(mapOf("type" to JsonPrimitive("boolean")))
 
-        List::class, Array::class -> {
+        List::class, Array::class, Set::class -> {
             val argType = kType.arguments.firstOrNull()?.type
             val itemsSchema = when {
                 argType != null -> getJsonSchemaForProperty(argType)

--- a/src/main/kotlin/net/portswigger/mcp/schema/serialization.kt
+++ b/src/main/kotlin/net/portswigger/mcp/schema/serialization.kt
@@ -5,6 +5,8 @@ import burp.api.montoya.proxy.ProxyWebSocketMessage
 import burp.api.montoya.scanner.audit.issues.AuditIssue
 import burp.api.montoya.websocket.Direction
 import kotlinx.serialization.Serializable
+import java.util.regex.Pattern
+import net.portswigger.mcp.tools.*
 
 fun AuditIssue.toSerializableForm(): IssueDetails {
     return IssueDetails(
@@ -49,6 +51,35 @@ fun ProxyHttpRequestResponse.toSerializableForm(): HttpRequestResponse {
         response = response()?.toString() ?: "<no response>",
         notes = annotations().notes()
     )
+}
+
+fun ProxyHttpRequestResponse.toSerializableForm(fields: Set<String>, extractPatterns: Map<String, String> = emptyMap()): Any {
+    return if (fields.isEmpty() && extractPatterns.isEmpty()) {
+        // Current behavior - return full HttpRequestResponse
+        HttpRequestResponse(
+            request = request()?.toString() ?: "<no request>",
+            response = response()?.toString() ?: "<no response>",
+            notes = annotations().notes()
+        )
+    } else {
+        // New behavior - return only requested fields and extracted patterns
+        FieldSelectiveResponse(
+            url = if ("url" in fields) request()?.url() else null,
+            method = if ("method" in fields) request()?.method() else null,
+            status = if ("status" in fields) response()?.statusCode()?.toInt() else null,
+            requestHeaders = if ("headers" in fields) 
+                request()?.headers()?.associate { it.name() to it.value() } else null,
+            responseHeaders = if ("headers" in fields) 
+                response()?.headers()?.associate { it.name() to it.value() } else null,
+            cookies = if ("cookies" in fields) extractSimpleCookies() else null,
+            links = if ("links" in fields) extractSimpleLinks() else null,
+            visibleText = if ("text" in fields) extractVisibleText() else null,
+            requestBody = if ("requestBody" in fields) extractRequestBody() else null,
+            responseBody = if ("responseBody" in fields) extractResponseBody() else null,
+            extractedPatterns = if (extractPatterns.isNotEmpty()) extractPatterns(extractPatterns) else null,
+            notes = annotations().notes()
+        )
+    }
 }
 
 fun ProxyWebSocketMessage.toSerializableForm(): WebSocketMessage {
@@ -133,4 +164,31 @@ data class WebSocketMessage(
     val payload: String?,
     val direction: WebSocketMessageDirection,
     val notes: String?
+)
+
+@Serializable
+data class FieldSelectiveResponse(
+    val url: String? = null,
+    val method: String? = null,
+    val status: Int? = null,
+    val requestHeaders: Map<String, String>? = null,
+    val responseHeaders: Map<String, String>? = null,
+    val cookies: List<String>? = null,
+    val links: List<String>? = null,
+    val visibleText: String? = null,
+    val requestBody: String? = null,
+    val responseBody: String? = null,
+    val extractedPatterns: Map<String, List<List<String>>>? = null,
+    val notes: String? = null
+)
+
+@Serializable
+data class SearchExcerpt(
+    val proxyId: String,
+    val url: String,
+    val method: String,
+    val status: Int?,
+    val excerpt: String,
+    val extractedGroups: List<List<String>>? = null,
+    val timestamp: Long
 )

--- a/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
@@ -798,3 +798,76 @@ class ToolsKtTest {
         }
     }
 }
+    @Nested
+    inner class NewFeaturesTests {
+        @Test
+        fun `field selection should work with basic fields`() {
+            val proxy = mockk<Proxy>()
+            val proxyHistory = listOf(mockk<ProxyHttpRequestResponse>())
+            every { api.proxy() } returns proxy
+            every { proxy.history() } returns proxyHistory
+            
+            mockkStatic("net.portswigger.mcp.schema.SerializationKt")
+            every { proxyHistory[0].toSerializableForm(any(), any()) } returns mockk()
+            
+            runBlocking {
+                val result = client.callTool(
+                    "get_proxy_http_history", mapOf(
+                        "count" to 1,
+                        "offset" to 0,
+                        "fields" to listOf("url", "method")
+                    )
+                )
+                delay(100)
+                assertNotNull(result)
+            }
+        }
+
+        @Test
+        fun `regex search with excerpts should work`() {
+            val proxy = mockk<Proxy>()
+            val proxyHistory = listOf(mockk<ProxyHttpRequestResponse>())
+            every { api.proxy() } returns proxy
+            every { proxy.history(any<(ProxyHttpRequestResponse) -> Boolean>()) } returns proxyHistory
+            
+            mockkStatic("net.portswigger.mcp.schema.SerializationKt")
+            every { proxyHistory[0].toSerializableForm() } returns mockk()
+            
+            runBlocking {
+                val result = client.callTool(
+                    "get_proxy_http_history_regex", mapOf(
+                        "regex" to "test",
+                        "count" to 1,
+                        "offset" to 0,
+                        "searchScope" to listOf("request"),
+                        "excerptLength" to 100
+                    )
+                )
+                delay(100)
+                assertNotNull(result)
+            }
+        }
+
+        @Test
+        fun `markdown output format should work`() {
+            val proxy = mockk<Proxy>()
+            val proxyHistory = listOf(mockk<ProxyHttpRequestResponse>())
+            every { api.proxy() } returns proxy
+            every { proxy.history() } returns proxyHistory
+            
+            mockkStatic("net.portswigger.mcp.schema.SerializationKt")
+            every { proxyHistory[0].toSerializableForm(any(), any()) } returns mockk()
+            
+            runBlocking {
+                val result = client.callTool(
+                    "get_proxy_http_history", mapOf(
+                        "count" to 1,
+                        "offset" to 0,
+                        "outputFormat" to "markdown"
+                    )
+                )
+                delay(100)
+                assertNotNull(result)
+            }
+        }
+    }


### PR DESCRIPTION
- Add optional field selection to get_proxy_http_history for targeted data extraction
- Enhance regex search with configurable excerpts and capture group extraction
- Add markdown output format support for improved AI client readability
- Add pattern extraction functionality for structured data analysis
- Maintain backward compatibility

433 lines changed (426 added, 7 removed)