### PR TITLE
Add Burp Collaborator MCP tools for OOB testing

### DIFF
--- a/src/main/kotlin/net/portswigger/mcp/schema/serialization.kt
+++ b/src/main/kotlin/net/portswigger/mcp/schema/serialization.kt
@@ -1,5 +1,6 @@
 package net.portswigger.mcp.schema
 
+import burp.api.montoya.collaborator.Interaction as CollaboratorInteraction
 import burp.api.montoya.proxy.ProxyHttpRequestResponse
 import burp.api.montoya.proxy.ProxyWebSocketMessage
 import burp.api.montoya.scanner.audit.issues.AuditIssue
@@ -133,4 +134,62 @@ data class WebSocketMessage(
     val payload: String?,
     val direction: WebSocketMessageDirection,
     val notes: String?
+)
+
+fun CollaboratorInteraction.toSerializableForm(): CollaboratorInteractionDetails {
+    return CollaboratorInteractionDetails(
+        id = id().toString(),
+        type = type().name,
+        timestamp = timeStamp().toString(),
+        clientIp = clientIp().hostAddress,
+        clientPort = clientPort(),
+        customData = customData().orElse(null),
+        dnsDetails = dnsDetails().orElse(null)?.let {
+            CollaboratorDnsDetails(queryType = it.queryType().name)
+        },
+        httpDetails = httpDetails().orElse(null)?.let {
+            CollaboratorHttpDetails(
+                protocol = it.protocol().name,
+                request = it.requestResponse()?.request()?.toString(),
+                response = it.requestResponse()?.response()?.toString()
+            )
+        },
+        smtpDetails = smtpDetails().orElse(null)?.let {
+            CollaboratorSmtpDetails(
+                protocol = it.protocol().name,
+                conversation = it.conversation()
+            )
+        }
+    )
+}
+
+@Serializable
+data class CollaboratorInteractionDetails(
+    val id: String,
+    val type: String,
+    val timestamp: String,
+    val clientIp: String,
+    val clientPort: Int,
+    val customData: String?,
+    val dnsDetails: CollaboratorDnsDetails?,
+    val httpDetails: CollaboratorHttpDetails?,
+    val smtpDetails: CollaboratorSmtpDetails?
+)
+
+@Serializable
+data class CollaboratorDnsDetails(
+    val queryType: String
+)
+
+@Serializable
+data class CollaboratorHttpDetails(
+    val protocol: String,
+    val request: String?,
+    val response: String?
+)
+
+@Serializable
+data class CollaboratorSmtpDetails(
+    val protocol: String,
+    val conversation: String
 )


### PR DESCRIPTION
## Summary
- Adds `generate_collaborator_payload` tool for generating Collaborator payloads with optional custom data for out-of-band vulnerability testing
- Adds `get_collaborator_interactions` tool for polling DNS/HTTP/SMTP interactions, with optional payload ID filtering
- Both tools are Professional-only, gated behind `BurpSuiteEdition.PROFESSIONAL` (same as scanner tools)

## Changes
- `serialization.kt`: Collaborator interaction serializable models and conversion extension function
- `Tools.kt`: Two tool registrations with shared lazy `CollaboratorClient`, plus input data classes
- `ToolsKtTest.kt`: 7 tests covering payload generation, DNS/HTTP/SMTP interactions, filtering, and edition gating

## Test plan
- [x] All 56 tests pass (`./gradlew test`)
- [x] Load extension in Burp Professional
- [x] Call `generate_collaborator_payload` and verify payload returned
- [x] Inject payload into a request, call `get_collaborator_interactions` and verify interactions returned

Closes #35