### PR TITLE
Feature: Get HTTP history by index number

### DIFF
--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -255,6 +255,15 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
             .map { truncateIfNeeded(Json.encodeToString(it.toSerializableForm())) }
     }
 
+    mcpTool<GetProxyHttpHistoryIndex>("Display single item within the proxy HTTP history by the specified index.") {
+        val requestResponse = api.proxy().history().getOrNull(index - 1)
+        if (requestResponse == null) {
+            "No HTTP history found at $index"
+        } else {
+            truncateIfNeeded(Json.encodeToString(requestResponse.toSerializableForm()))
+        }
+    }
+
     mcpPaginatedTool<GetProxyWebsocketHistory>("Displays items within the proxy WebSocket history") {
         val allowed = runBlocking {
             checkHistoryPermissionOrDeny(HistoryAccessType.WEBSOCKET_HISTORY, config, api, "WebSocket history")
@@ -410,6 +419,9 @@ data class GetProxyHttpHistory(override val count: Int, override val offset: Int
 
 @Serializable
 data class GetProxyHttpHistoryRegex(val regex: String, override val count: Int, override val offset: Int) : Paginated
+
+@Serializable
+data class GetProxyHttpHistoryIndex(val index: Int)
 
 @Serializable
 data class GetProxyWebsocketHistory(override val count: Int, override val offset: Int) : Paginated


### PR DESCRIPTION
# Summary
- Added `get_proxy_http_history_index` tool which allows a user to query a request response by the index in which they appear in the proxy history.

# Reason
- Faster than searching through the history via regex.
- Allows actions like `Use request #2518 as the base of a successful request. Generate and send payloads using the request etc.`

# Changes
- `Tools.kt`: One tool registration, plus input data classes.
