### PR TITLE
feat: add active audit MCP tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+### Worktrees ###
+.worktrees/

--- a/src/main/kotlin/net/portswigger/mcp/schema/serialization.kt
+++ b/src/main/kotlin/net/portswigger/mcp/schema/serialization.kt
@@ -7,6 +7,15 @@ import burp.api.montoya.scanner.audit.issues.AuditIssue
 import burp.api.montoya.websocket.Direction
 import kotlinx.serialization.Serializable
 
+private fun truncateResponseToHeaders(raw: String?): String {
+    if (raw == null) return "<no response>"
+    val separator = raw.indexOf("\r\n\r\n")
+    if (separator != -1) return raw.substring(0, separator)
+    val lfSeparator = raw.indexOf("\n\n")
+    if (lfSeparator != -1) return raw.substring(0, lfSeparator)
+    return raw
+}
+
 fun AuditIssue.toSerializableForm(): IssueDetails {
     return IssueDetails(
         name = name(),
@@ -20,7 +29,13 @@ fun AuditIssue.toSerializableForm(): IssueDetails {
         baseUrl = baseUrl(),
         severity = AuditIssueSeverity.valueOf(severity().name),
         confidence = AuditIssueConfidence.valueOf(confidence().name),
-        requestResponses = requestResponses().map { it.toSerializableForm() },
+        requestResponses = requestResponses().map {
+            HttpRequestResponse(
+                request = it.request()?.toString() ?: "<no request>",
+                response = truncateResponseToHeaders(it.response()?.toString()),
+                notes = it.annotations().notes()
+            )
+        },
         collaboratorInteractions = collaboratorInteractions().map {
             Interaction(
                 interactionId = it.id().toString(),

--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -8,10 +8,12 @@ import burp.api.montoya.core.BurpSuiteEdition
 import burp.api.montoya.http.HttpMode
 import burp.api.montoya.http.HttpService
 import burp.api.montoya.http.message.HttpHeader
+import burp.api.montoya.http.message.HttpRequestResponse
 import burp.api.montoya.http.message.requests.HttpRequest
 import burp.api.montoya.scanner.AuditConfiguration
 import burp.api.montoya.scanner.BuiltInAuditConfiguration
 import burp.api.montoya.scanner.CrawlConfiguration
+import burp.api.montoya.scanner.audit.Audit
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
@@ -42,6 +44,24 @@ private fun truncateIfNeeded(serialized: String): String {
         serialized.substring(0, 5000) + "... (truncated)"
     } else {
         serialized
+    }
+}
+
+internal fun addMatchingResponsesToAudit(
+    audit: Audit,
+    requestResponses: List<HttpRequestResponse>,
+    targetHost: String,
+    seen: MutableSet<String>,
+) {
+    requestResponses.forEach { requestResponse ->
+        if (requestResponse.response() == null) {
+            return@forEach
+        }
+
+        val url = requestResponse.request().url()
+        if (url.contains(targetHost) && seen.add(url)) {
+            audit.addRequestResponse(requestResponse)
+        }
     }
 }
 
@@ -255,12 +275,12 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
                 repeat(30) {
                     try {
                         Thread.sleep(2000)
-                        api.siteMap().requestResponses().forEach { requestResponse ->
-                            val url = requestResponse.request().url()
-                            if (url.contains(targetHost) && seen.add(url)) {
-                                audit.addRequestResponse(requestResponse)
-                            }
-                        }
+                        addMatchingResponsesToAudit(
+                            audit = audit,
+                            requestResponses = api.siteMap().requestResponses(),
+                            targetHost = targetHost,
+                            seen = seen,
+                        )
                     } catch (_: Exception) {
                     }
                 }

--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -304,9 +304,8 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
         }
 
         mcpTool<StartActiveAudit>(
-            "Starts a Burp active scan (crawl + audit) against the target URL. " +
-            "The crawl discovers pages and the audit checks for vulnerabilities. " +
-            "Results can be retrieved later via get_scanner_issues."
+            "Starts a Burp active scan (crawl + audit) for the target URL. " +
+            "Use get_scanner_issues to retrieve findings."
         ) {
             api.logging().logToOutput("MCP start_active_audit: starting active audit for $targetUrl")
             api.scope().includeInScope(targetUrl)
@@ -341,14 +340,12 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
                 }
             }.apply { isDaemon = true }.start()
 
-            "Active scan started for $targetUrl. " +
-            "Crawl discovering pages; audit checking for vulnerabilities. " +
-            "Use get_scanner_issues to retrieve findings (allow 30-60s for results)."
+            "Active scan started for $targetUrl. Use get_scanner_issues to retrieve findings."
         }
 
         mcpTool<StartActiveAuditForRequest>(
             "Starts a focused Burp active audit for a specific HTTP request. " +
-            "This tool does not start a crawl. Results can be retrieved later via get_scanner_issues."
+            "Use get_scanner_issues to retrieve findings."
         ) {
             val target = parseFocusedAuditTarget(targetUrl)
             validateFocusedAuditRequest(target, request)

--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -10,6 +10,7 @@ import burp.api.montoya.http.HttpService
 import burp.api.montoya.http.message.HttpHeader
 import burp.api.montoya.http.message.HttpRequestResponse
 import burp.api.montoya.http.message.requests.HttpRequest
+import burp.api.montoya.logging.Logging
 import burp.api.montoya.scanner.AuditConfiguration
 import burp.api.montoya.scanner.BuiltInAuditConfiguration
 import burp.api.montoya.scanner.CrawlConfiguration
@@ -52,15 +53,18 @@ internal fun addMatchingResponsesToAudit(
     requestResponses: List<HttpRequestResponse>,
     targetHost: String,
     seen: MutableSet<String>,
+    logging: Logging,
 ) {
     requestResponses.forEach { requestResponse ->
         if (requestResponse.response() == null) {
+            logging.logToOutput("MCP start_active_audit: skipping site map item without response")
             return@forEach
         }
 
         val url = requestResponse.request().url()
         if (url.contains(targetHost) && seen.add(url)) {
             audit.addRequestResponse(requestResponse)
+            logging.logToOutput("MCP start_active_audit: added site map item to audit: $url")
         }
     }
 }
@@ -258,16 +262,20 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
             "The crawl discovers pages and the audit checks for vulnerabilities. " +
             "Results can be retrieved later via get_scanner_issues."
         ) {
+            api.logging().logToOutput("MCP start_active_audit: starting active audit for $targetUrl")
             api.scope().includeInScope(targetUrl)
 
             val crawlConfig = CrawlConfiguration.crawlConfiguration(targetUrl)
             api.scanner().startCrawl(crawlConfig)
+            api.logging().logToOutput("MCP start_active_audit: crawl started for $targetUrl")
 
             val auditConfig = AuditConfiguration.auditConfiguration(
                 BuiltInAuditConfiguration.LEGACY_ACTIVE_AUDIT_CHECKS
             )
             val audit = api.scanner().startAudit(auditConfig)
+            api.logging().logToOutput("MCP start_active_audit: audit started for $targetUrl")
             audit.addRequest(HttpRequest.httpRequestFromUrl(targetUrl))
+            api.logging().logToOutput("MCP start_active_audit: added initial audit request for $targetUrl")
 
             val targetHost = java.net.URI(targetUrl).host
             val seen = mutableSetOf<String>()
@@ -280,6 +288,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
                             requestResponses = api.siteMap().requestResponses(),
                             targetHost = targetHost,
                             seen = seen,
+                            logging = api.logging(),
                         )
                     } catch (_: Exception) {
                     }

--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -9,6 +9,9 @@ import burp.api.montoya.http.HttpMode
 import burp.api.montoya.http.HttpService
 import burp.api.montoya.http.message.HttpHeader
 import burp.api.montoya.http.message.requests.HttpRequest
+import burp.api.montoya.scanner.AuditConfiguration
+import burp.api.montoya.scanner.BuiltInAuditConfiguration
+import burp.api.montoya.scanner.CrawlConfiguration
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
@@ -229,6 +232,44 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
                 }
             }
         }
+
+        mcpTool<StartActiveAudit>(
+            "Starts a Burp active scan (crawl + audit) against the target URL. " +
+            "The crawl discovers pages and the audit checks for vulnerabilities. " +
+            "Results can be retrieved later via get_scanner_issues."
+        ) {
+            api.scope().includeInScope(targetUrl)
+
+            val crawlConfig = CrawlConfiguration.crawlConfiguration(targetUrl)
+            api.scanner().startCrawl(crawlConfig)
+
+            val auditConfig = AuditConfiguration.auditConfiguration(
+                BuiltInAuditConfiguration.LEGACY_ACTIVE_AUDIT_CHECKS
+            )
+            val audit = api.scanner().startAudit(auditConfig)
+            audit.addRequest(HttpRequest.httpRequest(targetUrl))
+
+            val targetHost = java.net.URI(targetUrl).host
+            val seen = mutableSetOf<String>()
+            Thread {
+                repeat(30) {
+                    try {
+                        Thread.sleep(2000)
+                        api.siteMap().requestResponses().forEach { requestResponse ->
+                            val url = requestResponse.request().url()
+                            if (url.contains(targetHost) && seen.add(url)) {
+                                audit.addRequestResponse(requestResponse)
+                            }
+                        }
+                    } catch (_: Exception) {
+                    }
+                }
+            }.apply { isDaemon = true }.start()
+
+            "Active scan started for $targetUrl. " +
+            "Crawl discovering pages; audit checking for vulnerabilities. " +
+            "Use get_scanner_issues to retrieve findings (allow 30-60s for results)."
+        }
     }
 
     mcpPaginatedTool<GetProxyHttpHistory>("Displays items within the proxy HTTP history") {
@@ -427,3 +468,6 @@ data class GenerateCollaboratorPayload(
 data class GetCollaboratorInteractions(
     val payloadId: String? = null
 )
+
+@Serializable
+data class StartActiveAudit(val targetUrl: String)

--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -362,7 +362,8 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
             api.logging().logToOutput("MCP start_active_audit_for_request: audit started for $targetUrl")
 
             val service = HttpService.httpService(target.host, target.port, target.usesHttps)
-            val httpRequest = HttpRequest.httpRequest(service, request)
+            val fixedRequest = request.replace("\r", "").replace("\n", "\r\n")
+            val httpRequest = HttpRequest.httpRequest(service, fixedRequest)
 
             if (response != null) {
                 val httpResponse = HttpResponse.httpResponse(response)

--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -247,7 +247,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
                 BuiltInAuditConfiguration.LEGACY_ACTIVE_AUDIT_CHECKS
             )
             val audit = api.scanner().startAudit(auditConfig)
-            audit.addRequest(HttpRequest.httpRequest(targetUrl))
+            audit.addRequest(HttpRequest.httpRequestFromUrl(targetUrl))
 
             val targetHost = java.net.URI(targetUrl).host
             val seen = mutableSetOf<String>()

--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -10,6 +10,7 @@ import burp.api.montoya.http.HttpService
 import burp.api.montoya.http.message.HttpHeader
 import burp.api.montoya.http.message.HttpRequestResponse
 import burp.api.montoya.http.message.requests.HttpRequest
+import burp.api.montoya.http.message.responses.HttpResponse
 import burp.api.montoya.logging.Logging
 import burp.api.montoya.scanner.AuditConfiguration
 import burp.api.montoya.scanner.BuiltInAuditConfiguration
@@ -27,6 +28,51 @@ import net.portswigger.mcp.security.HttpRequestSecurity
 import java.awt.KeyboardFocusManager
 import java.util.regex.Pattern
 import javax.swing.JTextArea
+
+private data class FocusedAuditTarget(
+    val uri: java.net.URI,
+    val host: String,
+    val port: Int,
+    val usesHttps: Boolean,
+)
+
+private fun parseFocusedAuditTarget(targetUrl: String): FocusedAuditTarget {
+    val uri = java.net.URI(targetUrl)
+    val scheme = uri.scheme?.lowercase() ?: throw IllegalArgumentException("targetUrl must include a scheme")
+    val host = uri.host ?: throw IllegalArgumentException("targetUrl must include a host")
+    val usesHttps = when (scheme) {
+        "https" -> true
+        "http" -> false
+        else -> throw IllegalArgumentException("targetUrl scheme must be http or https")
+    }
+    val port = if (uri.port != -1) uri.port else if (usesHttps) 443 else 80
+    return FocusedAuditTarget(uri, host, port, usesHttps)
+}
+
+private fun validateFocusedAuditRequest(target: FocusedAuditTarget, request: String) {
+    if (request.isBlank()) {
+        throw IllegalArgumentException("request must not be blank")
+    }
+
+    val lines = request.replace("\r\n", "\n").split('\n')
+    if (lines.isEmpty() || lines.first().isBlank()) {
+        throw IllegalArgumentException("request must include a request line")
+    }
+
+    val hostHeader = lines
+        .drop(1)
+        .takeWhile { it.isNotEmpty() }
+        .firstOrNull { it.startsWith("Host:", ignoreCase = true) }
+        ?.substringAfter(':')
+        ?.trim()
+
+    if (hostHeader != null) {
+        val requestHost = hostHeader.substringBefore(':').trim()
+        if (!requestHost.equals(target.host, ignoreCase = true)) {
+            throw IllegalArgumentException("request host must match targetUrl host")
+        }
+    }
+}
 
 private suspend fun checkHistoryPermissionOrDeny(
     accessType: HistoryAccessType, config: McpConfig, api: MontoyaApi, logMessage: String
@@ -299,6 +345,37 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
             "Crawl discovering pages; audit checking for vulnerabilities. " +
             "Use get_scanner_issues to retrieve findings (allow 30-60s for results)."
         }
+
+        mcpTool<StartActiveAuditForRequest>(
+            "Starts a focused Burp active audit for a specific HTTP request. " +
+            "This tool does not start a crawl. Results can be retrieved later via get_scanner_issues."
+        ) {
+            val target = parseFocusedAuditTarget(targetUrl)
+            validateFocusedAuditRequest(target, request)
+            api.logging().logToOutput("MCP start_active_audit_for_request: starting focused audit for $targetUrl")
+            api.scope().includeInScope(targetUrl)
+
+            val auditConfig = AuditConfiguration.auditConfiguration(
+                BuiltInAuditConfiguration.LEGACY_ACTIVE_AUDIT_CHECKS
+            )
+            val audit = api.scanner().startAudit(auditConfig)
+            api.logging().logToOutput("MCP start_active_audit_for_request: audit started for $targetUrl")
+
+            val service = HttpService.httpService(target.host, target.port, target.usesHttps)
+            val httpRequest = HttpRequest.httpRequest(service, request)
+
+            if (response != null) {
+                val httpResponse = HttpResponse.httpResponse(response)
+                val requestResponse = HttpRequestResponse.httpRequestResponse(httpRequest, httpResponse)
+                audit.addRequestResponse(requestResponse)
+                api.logging().logToOutput("MCP start_active_audit_for_request: injected request-response for $targetUrl")
+            } else {
+                audit.addRequest(httpRequest)
+                api.logging().logToOutput("MCP start_active_audit_for_request: injected request for $targetUrl")
+            }
+
+            "Focused active audit started for $targetUrl. No crawl was started. Use get_scanner_issues to retrieve findings."
+        }
     }
 
     mcpPaginatedTool<GetProxyHttpHistory>("Displays items within the proxy HTTP history") {
@@ -500,3 +577,10 @@ data class GetCollaboratorInteractions(
 
 @Serializable
 data class StartActiveAudit(val targetUrl: String)
+
+@Serializable
+data class StartActiveAuditForRequest(
+    val targetUrl: String,
+    val request: String,
+    val response: String? = null
+)

--- a/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
@@ -1024,6 +1024,10 @@ class ToolsKtTest {
 
             verify(exactly = 1) { HttpRequest.httpRequestFromUrl("https://example.com") }
             verify(exactly = 1) { audit.addRequest(request) }
+            verify { api.logging().logToOutput(match { it.contains("starting active audit for https://example.com") }) }
+            verify { api.logging().logToOutput(match { it.contains("crawl started for https://example.com") }) }
+            verify { api.logging().logToOutput(match { it.contains("audit started for https://example.com") }) }
+            verify { api.logging().logToOutput(match { it.contains("added initial audit request for https://example.com") }) }
             unmockkStatic(burp.api.montoya.scanner.CrawlConfiguration::class)
             unmockkStatic(burp.api.montoya.scanner.AuditConfiguration::class)
         }
@@ -1033,6 +1037,7 @@ class ToolsKtTest {
             val audit = mockk<burp.api.montoya.scanner.audit.Audit>(relaxed = true)
             val request = mockk<HttpRequest>()
             val requestResponse = mockk<burp.api.montoya.http.message.HttpRequestResponse>()
+            val logging = mockk<Logging>(relaxed = true)
 
             every { requestResponse.request() } returns request
             every { request.url() } returns "https://example.com/filter"
@@ -1043,9 +1048,11 @@ class ToolsKtTest {
                 requestResponses = listOf(requestResponse),
                 targetHost = "example.com",
                 seen = mutableSetOf(),
+                logging = logging,
             )
 
             verify(exactly = 0) { audit.addRequestResponse(any<burp.api.montoya.http.message.HttpRequestResponse>()) }
+            verify { logging.logToOutput(match { it.contains("skipping site map item without response") }) }
         }
     }
 

--- a/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
@@ -1027,6 +1027,26 @@ class ToolsKtTest {
             unmockkStatic(burp.api.montoya.scanner.CrawlConfiguration::class)
             unmockkStatic(burp.api.montoya.scanner.AuditConfiguration::class)
         }
+
+        @Test
+        fun `start active audit should skip site map entries without responses`() {
+            val audit = mockk<burp.api.montoya.scanner.audit.Audit>(relaxed = true)
+            val request = mockk<HttpRequest>()
+            val requestResponse = mockk<burp.api.montoya.http.message.HttpRequestResponse>()
+
+            every { requestResponse.request() } returns request
+            every { request.url() } returns "https://example.com/filter"
+            every { requestResponse.response() } returns null
+
+            addMatchingResponsesToAudit(
+                audit = audit,
+                requestResponses = listOf(requestResponse),
+                targetHost = "example.com",
+                seen = mutableSetOf(),
+            )
+
+            verify(exactly = 0) { audit.addRequestResponse(any<burp.api.montoya.http.message.HttpRequestResponse>()) }
+        }
     }
 
     @Test

--- a/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
@@ -1033,6 +1033,169 @@ class ToolsKtTest {
         }
 
         @Test
+        fun `start active audit for request should start focused audit without crawl`() {
+            val scanner = mockk<burp.api.montoya.scanner.Scanner>()
+            val scope = mockk<burp.api.montoya.scope.Scope>(relaxed = true)
+            val audit = mockk<burp.api.montoya.scanner.audit.Audit>(relaxed = true)
+            val auditConfig = mockk<burp.api.montoya.scanner.AuditConfiguration>()
+            val httpRequest = mockk<HttpRequest>()
+
+            mockkStatic(burp.api.montoya.scanner.AuditConfiguration::class)
+
+            every { api.scope() } returns scope
+            every { api.scanner() } returns scanner
+            every {
+                burp.api.montoya.scanner.AuditConfiguration.auditConfiguration(
+                    burp.api.montoya.scanner.BuiltInAuditConfiguration.LEGACY_ACTIVE_AUDIT_CHECKS
+                )
+            } returns auditConfig
+            every { scanner.startAudit(auditConfig) } returns audit
+            every { HttpRequest.httpRequest(any<burp.api.montoya.http.HttpService>(), any<String>()) } returns httpRequest
+
+            runBlocking {
+                val result = client.callTool(
+                    "start_active_audit_for_request",
+                    mapOf(
+                        "targetUrl" to "http://example.com:8080/login",
+                        "request" to "POST /login HTTP/1.1\r\nHost: example.com:8080\r\nContent-Length: 10\r\n\r\nusername=a"
+                    )
+                )
+                delay(100)
+                val text = result.expectTextContent()
+                assertTrue(text.contains("Focused active audit started"))
+                assertTrue(text.contains("http://example.com:8080/login"))
+                assertFalse(text.contains("Error"))
+            }
+
+            verify(exactly = 1) { scope.includeInScope("http://example.com:8080/login") }
+            verify(exactly = 1) { burp.api.montoya.http.HttpService.httpService("example.com", 8080, false) }
+            verify(exactly = 1) { scanner.startAudit(auditConfig) }
+            verify(exactly = 1) { audit.addRequest(httpRequest) }
+            verify(exactly = 0) { scanner.startCrawl(any()) }
+            verify { api.logging().logToOutput(match { it.contains("start_active_audit_for_request") }) }
+
+            unmockkStatic(burp.api.montoya.scanner.AuditConfiguration::class)
+        }
+
+        @Test
+        fun `start active audit for request should seed audit with request response when response is provided`() {
+            val scanner = mockk<burp.api.montoya.scanner.Scanner>()
+            val scope = mockk<burp.api.montoya.scope.Scope>(relaxed = true)
+            val audit = mockk<burp.api.montoya.scanner.audit.Audit>(relaxed = true)
+            val auditConfig = mockk<burp.api.montoya.scanner.AuditConfiguration>()
+            val httpRequest = mockk<HttpRequest>()
+            val httpResponse = mockk<burp.api.montoya.http.message.responses.HttpResponse>()
+            val requestResponse = mockk<burp.api.montoya.http.message.HttpRequestResponse>()
+
+            mockkStatic(burp.api.montoya.scanner.AuditConfiguration::class)
+            mockkStatic(burp.api.montoya.http.message.responses.HttpResponse::class)
+            mockkStatic(burp.api.montoya.http.message.HttpRequestResponse::class)
+
+            every { api.scope() } returns scope
+            every { api.scanner() } returns scanner
+            every {
+                burp.api.montoya.scanner.AuditConfiguration.auditConfiguration(
+                    burp.api.montoya.scanner.BuiltInAuditConfiguration.LEGACY_ACTIVE_AUDIT_CHECKS
+                )
+            } returns auditConfig
+            every { scanner.startAudit(auditConfig) } returns audit
+            every { HttpRequest.httpRequest(any<burp.api.montoya.http.HttpService>(), any<String>()) } returns httpRequest
+            every { burp.api.montoya.http.message.responses.HttpResponse.httpResponse(any<String>()) } returns httpResponse
+            every { burp.api.montoya.http.message.HttpRequestResponse.httpRequestResponse(httpRequest, httpResponse) } returns requestResponse
+
+            runBlocking {
+                val result = client.callTool(
+                    "start_active_audit_for_request",
+                    mapOf(
+                        "targetUrl" to "https://example.com/login",
+                        "request" to "POST /login HTTP/1.1\r\nHost: example.com\r\n\r\nusername=a",
+                        "response" to "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\nok"
+                    )
+                )
+                delay(100)
+                val text = result.expectTextContent()
+                assertTrue(text.contains("Focused active audit started"), "Expected success but got: $text")
+                assertFalse(text.contains("Error"), "Unexpected error: $text")
+            }
+
+            verify(exactly = 1) { audit.addRequestResponse(requestResponse) }
+            verify(exactly = 0) { audit.addRequest(any()) }
+
+            unmockkStatic(burp.api.montoya.scanner.AuditConfiguration::class)
+            unmockkStatic(burp.api.montoya.http.message.responses.HttpResponse::class)
+            unmockkStatic(burp.api.montoya.http.message.HttpRequestResponse::class)
+        }
+
+        @Test
+        fun `start active audit for request should reject invalid targetUrl without scheme`() {
+            val scanner = mockk<burp.api.montoya.scanner.Scanner>()
+            every { api.scanner() } returns scanner
+
+            runBlocking {
+                val result = client.callTool(
+                    "start_active_audit_for_request",
+                    mapOf(
+                        "targetUrl" to "example.com/login",
+                        "request" to "GET /login HTTP/1.1\r\nHost: example.com\r\n\r\n"
+                    )
+                )
+                delay(100)
+                val text = result.expectTextContent()
+                assertTrue(text.contains("Error:"), "Expected error response but got: $text")
+                assertTrue(text.contains("targetUrl must include a scheme") || text.contains("targetUrl must include a host"),
+                    "Expected validation message but got: $text")
+            }
+
+            verify(exactly = 0) { scanner.startAudit(any()) }
+        }
+
+        @Test
+        fun `start active audit for request should reject blank request`() {
+            val scanner = mockk<burp.api.montoya.scanner.Scanner>()
+            every { api.scanner() } returns scanner
+
+            runBlocking {
+                val result = client.callTool(
+                    "start_active_audit_for_request",
+                    mapOf(
+                        "targetUrl" to "https://example.com/login",
+                        "request" to "   "
+                    )
+                )
+                delay(100)
+                val text = result.expectTextContent()
+                assertTrue(text.contains("Error:"), "Expected error response but got: $text")
+                assertTrue(text.contains("request must not be blank"), "Expected blank validation but got: $text")
+            }
+
+            verify(exactly = 0) { scanner.startAudit(any()) }
+        }
+
+        @Test
+        fun `start active audit for request should reject host mismatch`() {
+            val scanner = mockk<burp.api.montoya.scanner.Scanner>()
+            val scope = mockk<burp.api.montoya.scope.Scope>(relaxed = true)
+            every { api.scanner() } returns scanner
+            every { api.scope() } returns scope
+
+            runBlocking {
+                val result = client.callTool(
+                    "start_active_audit_for_request",
+                    mapOf(
+                        "targetUrl" to "https://example.com/login",
+                        "request" to "POST /login HTTP/1.1\r\nHost: other.example\r\n\r\nusername=a"
+                    )
+                )
+                delay(100)
+                val text = result.expectTextContent()
+                assertTrue(text.contains("Error:"), "Expected error response but got: $text")
+                assertTrue(text.contains("request host must match targetUrl host"), "Expected host mismatch error but got: $text")
+            }
+
+            verify(exactly = 0) { scanner.startAudit(any()) }
+        }
+
+        @Test
         fun `start active audit should skip site map entries without responses`() {
             val audit = mockk<burp.api.montoya.scanner.audit.Audit>(relaxed = true)
             val request = mockk<HttpRequest>()
@@ -1078,6 +1241,7 @@ class ToolsKtTest {
             assertFalse(tools.any { it.name == "start_active_audit" })
             assertFalse(tools.any { it.name == "generate_collaborator_payload" })
             assertFalse(tools.any { it.name == "get_collaborator_interactions" })
+            assertFalse(tools.any { it.name == "start_active_audit_for_request" })
         }
 
         every { version.edition() } returns BurpSuiteEdition.PROFESSIONAL
@@ -1101,6 +1265,7 @@ class ToolsKtTest {
             val tools = client.listTools()
             assertTrue(tools.any { it.name == "get_scanner_issues" })
             assertTrue(tools.any { it.name == "start_active_audit" })
+            assertTrue(tools.any { it.name == "start_active_audit_for_request" })
             assertTrue(tools.any { it.name == "generate_collaborator_payload" })
             assertTrue(tools.any { it.name == "get_collaborator_interactions" })
         }

--- a/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
@@ -982,6 +982,51 @@ class ToolsKtTest {
                 result.expectTextContent("No interactions detected")
             }
         }
+
+        @Test
+        fun `start active audit should build initial request from target url`() {
+            val scanner = mockk<burp.api.montoya.scanner.Scanner>()
+            val scope = mockk<burp.api.montoya.scope.Scope>(relaxed = true)
+            val siteMap = mockk<burp.api.montoya.sitemap.SiteMap>()
+            val crawl = mockk<burp.api.montoya.scanner.Crawl>(relaxed = true)
+            val crawlConfig = mockk<burp.api.montoya.scanner.CrawlConfiguration>()
+            val audit = mockk<burp.api.montoya.scanner.audit.Audit>(relaxed = true)
+            val auditConfig = mockk<burp.api.montoya.scanner.AuditConfiguration>()
+            val request = mockk<HttpRequest>()
+
+            mockkStatic(burp.api.montoya.scanner.CrawlConfiguration::class)
+            mockkStatic(burp.api.montoya.scanner.AuditConfiguration::class)
+
+            every { api.scope() } returns scope
+            every { api.scanner() } returns scanner
+            every { api.siteMap() } returns siteMap
+            every { siteMap.requestResponses() } returns emptyList()
+            every { burp.api.montoya.scanner.CrawlConfiguration.crawlConfiguration("https://example.com") } returns crawlConfig
+            every {
+                burp.api.montoya.scanner.AuditConfiguration.auditConfiguration(
+                    burp.api.montoya.scanner.BuiltInAuditConfiguration.LEGACY_ACTIVE_AUDIT_CHECKS
+                )
+            } returns auditConfig
+            every { scanner.startCrawl(crawlConfig) } returns crawl
+            every { scanner.startAudit(auditConfig) } returns audit
+            every { HttpRequest.httpRequestFromUrl("https://example.com") } returns request
+
+            runBlocking {
+                val result = client.callTool(
+                    "start_active_audit", mapOf(
+                        "targetUrl" to "https://example.com"
+                    )
+                )
+                delay(100)
+                val text = result.expectTextContent()
+                assertTrue(text.contains("Active scan started for https://example.com"))
+            }
+
+            verify(exactly = 1) { HttpRequest.httpRequestFromUrl("https://example.com") }
+            verify(exactly = 1) { audit.addRequest(request) }
+            unmockkStatic(burp.api.montoya.scanner.CrawlConfiguration::class)
+            unmockkStatic(burp.api.montoya.scanner.AuditConfiguration::class)
+        }
     }
 
     @Test

--- a/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
@@ -1003,6 +1003,7 @@ class ToolsKtTest {
         runBlocking {
             val tools = client.listTools()
             assertFalse(tools.any { it.name == "get_scanner_issues" })
+            assertFalse(tools.any { it.name == "start_active_audit" })
             assertFalse(tools.any { it.name == "generate_collaborator_payload" })
             assertFalse(tools.any { it.name == "get_collaborator_interactions" })
         }
@@ -1027,6 +1028,7 @@ class ToolsKtTest {
 
             val tools = client.listTools()
             assertTrue(tools.any { it.name == "get_scanner_issues" })
+            assertTrue(tools.any { it.name == "start_active_audit" })
             assertTrue(tools.any { it.name == "generate_collaborator_payload" })
             assertTrue(tools.any { it.name == "get_collaborator_interactions" })
         }


### PR DESCRIPTION
## Summary

- Add `start_active_audit` tool for full crawl + audit scanning
- Add `start_active_audit_for_request` tool for focused audit without crawl
- Truncate scanner issue responses to status line + headers for consistency

## Changes

- New `start_active_audit` and `start_active_audit_for_request` tools registered in Tools.kt
- Response truncation in serialization.kt
- Unit tests in ToolsKtTest.kt
- Add .worktrees/ to .gitignore for isolated development

## Test Plan

- [x] Unit tests pass
- [x] Manual testing in Burp Suite
- [x] Build succeeds

Note: The pre-existing `McpServerIntegrationTest` has a known flaky issue unrelated to these changes (verified by testing against upstream/main).