### PR TITLE
Add MCP tools for crawl and active audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Upon successful loading, the MCP Server Extension will be active within Burp Sui
 Configuration for the extension is done through the Burp Suite UI in the `MCP` tab.
 - **Toggle the MCP Server**: The `Enabled` checkbox controls whether the MCP server is active.
 - **Enable config editing**: The `Enable tools that can edit your config` checkbox allows the MCP server to expose tools which can edit Burp configuration files.
+- **HTTP approval semantics**: Active audit tools reuse the existing HTTP request approval setting and auto-approved target list. If a host or host:port is already approved for HTTP requests, active audits for the same target will not prompt again.
+- **Active audit lifetime**: `start_active_audit` accepts an optional `scanDurationSeconds`. When provided, the crawl and audit stop automatically when the time limit is reached. When omitted, the scan keeps running until `stop_active_audit` is called.
 - **Advanced options**: You can configure the port and host for the MCP server. By default, it listens on `http://127.0.0.1:9876`.
 
 ### Claude Desktop Client

--- a/src/main/kotlin/net/portswigger/mcp/security/AuditSwingUserApprovalHandler.kt
+++ b/src/main/kotlin/net/portswigger/mcp/security/AuditSwingUserApprovalHandler.kt
@@ -1,0 +1,63 @@
+package net.portswigger.mcp.security
+
+import burp.api.montoya.MontoyaApi
+import net.portswigger.mcp.config.Dialogs
+import net.portswigger.mcp.config.McpConfig
+import javax.swing.SwingUtilities
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+class AuditSwingUserApprovalHandler : UserApprovalHandler {
+    override suspend fun requestApproval(
+        hostname: String,
+        port: Int,
+        config: McpConfig,
+        requestContent: String?,
+        api: MontoyaApi?
+    ): Boolean {
+        return suspendCoroutine { continuation ->
+            SwingUtilities.invokeLater {
+                val message = buildString {
+                    appendLine("An MCP client is requesting to start an active scan on:")
+                    appendLine()
+                    appendLine("Target: $hostname:$port")
+                    appendLine()
+                }
+
+                val auditDetails = buildString {
+                    appendLine("=== Active Scan Request ===")
+                    appendLine()
+                    appendLine("Target: $hostname:$port")
+                    appendLine()
+                    appendLine("WARNING: Active scans will crawl and probe")
+                    appendLine("the target automatically, potentially sending")
+                    appendLine("many requests.")
+                    appendLine()
+                    appendLine("Only approve targets you are authorized to test.")
+                }
+
+                val options = arrayOf(
+                    "Allow Once", "Always Allow Host", "Always Allow Host:Port", "Deny"
+                )
+
+                val burpFrame = findBurpFrame()
+                val result = Dialogs.showOptionDialog(
+                    burpFrame, message, options, auditDetails, api
+                )
+
+                when (result) {
+                    0 -> continuation.resume(true)
+                    1 -> {
+                        config.addAutoApproveTarget(hostname)
+                        continuation.resume(true)
+                    }
+                    2 -> {
+                        config.addAutoApproveTarget("$hostname:$port")
+                        continuation.resume(true)
+                    }
+                    else -> continuation.resume(false)
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/net/portswigger/mcp/security/HttpRequestSecurity.kt
+++ b/src/main/kotlin/net/portswigger/mcp/security/HttpRequestSecurity.kt
@@ -63,6 +63,7 @@ class SwingUserApprovalHandler : UserApprovalHandler {
 object HttpRequestSecurity {
 
     var approvalHandler: UserApprovalHandler = SwingUserApprovalHandler()
+    var auditApprovalHandler: UserApprovalHandler = AuditSwingUserApprovalHandler()
 
     private fun isAutoApproved(hostname: String, port: Int, config: McpConfig): Boolean {
         val target = "$hostname:$port"
@@ -116,5 +117,19 @@ object HttpRequestSecurity {
         }
 
         return approvalHandler.requestApproval(hostname, port, config, requestContent, api)
+    }
+
+    suspend fun checkAuditPermission(
+        hostname: String, port: Int, config: McpConfig, api: MontoyaApi? = null
+    ): Boolean {
+        if (!config.requireHttpRequestApproval) {
+            return true
+        }
+
+        if (isAutoApproved(hostname, port, config)) {
+            return true
+        }
+
+        return auditApprovalHandler.requestApproval(hostname, port, config, null, api)
     }
 }

--- a/src/main/kotlin/net/portswigger/mcp/tools/ActiveAuditRegistry.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/ActiveAuditRegistry.kt
@@ -1,0 +1,105 @@
+package net.portswigger.mcp.tools
+
+import burp.api.montoya.scanner.Crawl
+import burp.api.montoya.scanner.audit.Audit
+import java.util.concurrent.atomic.AtomicInteger
+
+data class ActiveAuditEntry(
+    val crawl: Crawl?,
+    val audit: Audit,
+    val pollingThread: Thread?,
+    val cleanup: (() -> Unit)? = null,
+)
+
+data class StopAllResult(val total: Int, val failed: Int, val errors: List<String>)
+
+class ActiveAuditRegistry {
+    private val entries = LinkedHashMap<String, ActiveAuditEntry>()
+    private val counter = AtomicInteger(0)
+
+    @Synchronized
+    fun register(
+        crawl: Crawl? = null,
+        audit: Audit,
+        pollingThread: Thread? = null,
+        cleanup: (() -> Unit)? = null,
+    ): String {
+        val id = "audit-${counter.incrementAndGet()}"
+        entries[id] = ActiveAuditEntry(crawl, audit, pollingThread, cleanup)
+        return id
+    }
+
+    private fun stopEntry(
+        entry: ActiveAuditEntry,
+        interruptPollingThread: Boolean,
+        formatError: (action: String, error: Exception) -> String,
+    ): List<String> {
+        val errors = mutableListOf<String>()
+
+        if (interruptPollingThread && entry.pollingThread != null && entry.pollingThread != Thread.currentThread()) {
+            try {
+                entry.pollingThread.interrupt()
+            } catch (_: Exception) {}
+        }
+
+        try {
+            entry.audit.delete()
+        } catch (e: Exception) {
+            errors.add(formatError("audit delete", e))
+        }
+
+        try {
+            entry.crawl?.delete()
+        } catch (e: Exception) {
+            errors.add(formatError("crawl delete", e))
+        }
+
+        try {
+            entry.cleanup?.invoke()
+        } catch (e: Exception) {
+            errors.add(formatError("cleanup", e))
+        }
+
+        return errors
+    }
+
+    fun stopAll(): StopAllResult {
+        val snapshot: Map<String, ActiveAuditEntry>
+        synchronized(this) {
+            snapshot = entries.toMap()
+            entries.clear()
+        }
+
+        val errors = mutableListOf<String>()
+        snapshot.forEach { (id, entry) ->
+            errors += stopEntry(entry, interruptPollingThread = true) { action, error ->
+                "$id $action: ${error.message}"
+            }
+        }
+
+        return StopAllResult(snapshot.size, errors.size, errors)
+    }
+
+    fun stopById(id: String, interruptPollingThread: Boolean = true): String? {
+        val entry: ActiveAuditEntry
+        synchronized(this) {
+            entry = entries.remove(id) ?: return null
+        }
+
+        val errors = stopEntry(entry, interruptPollingThread) { action, error ->
+            "$action failed: ${error.message}"
+        }
+
+        return if (errors.isEmpty()) {
+            "Stopped audit $id"
+        } else {
+            "Stopped audit $id (${errors.joinToString("; ")})"
+        }
+    }
+
+    @Synchronized
+    fun clear() {
+        entries.clear()
+        counter.set(0)
+    }
+}

--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -8,7 +8,14 @@ import burp.api.montoya.core.BurpSuiteEdition
 import burp.api.montoya.http.HttpMode
 import burp.api.montoya.http.HttpService
 import burp.api.montoya.http.message.HttpHeader
+import burp.api.montoya.http.message.HttpRequestResponse
 import burp.api.montoya.http.message.requests.HttpRequest
+import burp.api.montoya.http.message.responses.HttpResponse
+import burp.api.montoya.logging.Logging
+import burp.api.montoya.scanner.AuditConfiguration
+import burp.api.montoya.scanner.BuiltInAuditConfiguration
+import burp.api.montoya.scanner.CrawlConfiguration
+import burp.api.montoya.scanner.audit.Audit
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
@@ -21,6 +28,147 @@ import net.portswigger.mcp.security.HttpRequestSecurity
 import java.awt.KeyboardFocusManager
 import java.util.regex.Pattern
 import javax.swing.JTextArea
+
+private data class FocusedAuditTarget(
+    val uri: java.net.URI,
+    val host: String,
+    val port: Int,
+    val usesHttps: Boolean,
+)
+
+private fun normalizedPath(path: String?): String {
+    if (path.isNullOrBlank()) {
+        return "/"
+    }
+    return if (path.startsWith("/")) path else "/$path"
+}
+
+private fun resolvedPort(uri: java.net.URI): Int? {
+    if (uri.port != -1) {
+        return uri.port
+    }
+
+    return when (uri.scheme?.lowercase()) {
+        "https" -> 443
+        "http" -> 80
+        else -> null
+    }
+}
+
+private fun isPathWithinScope(requestPath: String?, targetPath: String?): Boolean {
+    val normalizedTargetPath = normalizedPath(targetPath).removeSuffix("/").ifEmpty { "/" }
+    if (normalizedTargetPath == "/") {
+        return true
+    }
+
+    val normalizedRequestPath = normalizedPath(requestPath).removeSuffix("/").ifEmpty { "/" }
+    return normalizedRequestPath == normalizedTargetPath || normalizedRequestPath.startsWith("$normalizedTargetPath/")
+}
+
+private fun matchesFocusedAuditTarget(requestUri: java.net.URI, target: FocusedAuditTarget): Boolean {
+    val requestScheme = requestUri.scheme?.lowercase() ?: return false
+    val targetScheme = target.uri.scheme?.lowercase() ?: return false
+    if (requestScheme != targetScheme) {
+        return false
+    }
+
+    val requestHost = requestUri.host ?: return false
+    if (!requestHost.equals(target.host, ignoreCase = true)) {
+        return false
+    }
+
+    val requestPort = resolvedPort(requestUri) ?: return false
+    if (requestPort != target.port) {
+        return false
+    }
+
+    return isPathWithinScope(requestUri.path, target.uri.path)
+}
+
+private fun parseFocusedAuditTarget(targetUrl: String): FocusedAuditTarget {
+    val uri = java.net.URI(targetUrl)
+    val scheme = uri.scheme?.lowercase() ?: throw IllegalArgumentException("targetUrl must include a scheme")
+    val host = uri.host ?: throw IllegalArgumentException("targetUrl must include a host")
+    val usesHttps = when (scheme) {
+        "https" -> true
+        "http" -> false
+        else -> throw IllegalArgumentException("targetUrl scheme must be http or https")
+    }
+    val port = if (uri.port != -1) uri.port else if (usesHttps) 443 else 80
+    return FocusedAuditTarget(uri, host, port, usesHttps)
+}
+
+private fun validateFocusedAuditRequest(target: FocusedAuditTarget, request: String) {
+    if (request.isBlank()) {
+        throw IllegalArgumentException("request must not be blank")
+    }
+
+    val lines = request.replace("\r\n", "\n").split('\n')
+    if (lines.isEmpty() || lines.first().isBlank()) {
+        throw IllegalArgumentException("request must include a request line")
+    }
+
+    val hostHeader = lines
+        .drop(1)
+        .takeWhile { it.isNotEmpty() }
+        .firstOrNull { it.startsWith("Host:", ignoreCase = true) }
+        ?.substringAfter(':')
+        ?.trim()
+
+    if (hostHeader != null) {
+        val requestHost = hostHeader.substringBefore(':').trim()
+        if (!requestHost.equals(target.host, ignoreCase = true)) {
+            throw IllegalArgumentException("request host must match targetUrl host")
+        }
+    }
+}
+
+private fun addMatchingResponsesToAudit(
+    audit: Audit,
+    requestResponses: List<HttpRequestResponse>,
+    target: FocusedAuditTarget,
+    seen: MutableSet<String>,
+    logging: Logging,
+) {
+    requestResponses.forEach { requestResponse ->
+        if (requestResponse.response() == null) {
+            return@forEach
+        }
+
+        val request = requestResponse.request()
+        val url = request.url()
+        val method = request.method()
+
+        try {
+            val requestUri = java.net.URI(url)
+            if (matchesFocusedAuditTarget(requestUri, target)) {
+                val dedupKey = "$method:$url"
+                if (seen.add(dedupKey)) {
+                    audit.addRequestResponse(requestResponse)
+                    logging.logToOutput("MCP start_active_audit: added site map item to audit: $url")
+                }
+            }
+        } catch (_: Exception) {
+            // Skip malformed URLs
+        }
+    }
+}
+
+private fun validateScanDuration(scanDurationSeconds: Int?) {
+    if (scanDurationSeconds != null && scanDurationSeconds <= 0) {
+        throw IllegalArgumentException("scanDurationSeconds must be greater than 0")
+    }
+}
+
+private fun includeInScopeIfNeeded(api: MontoyaApi, targetUrl: String): (() -> Unit)? {
+    val scope = api.scope()
+    if (scope.isInScope(targetUrl)) {
+        return null
+    }
+
+    scope.includeInScope(targetUrl)
+    return { scope.excludeFromScope(targetUrl) }
+}
 
 private suspend fun checkHistoryPermissionOrDeny(
     accessType: HistoryAccessType, config: McpConfig, api: MontoyaApi, logMessage: String
@@ -185,6 +333,8 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
     }
 
     if (api.burpSuite().version().edition() == BurpSuiteEdition.PROFESSIONAL) {
+        val auditRegistry = ActiveAuditRegistry()
+
         mcpPaginatedTool<GetScannerIssues>("Displays information about issues identified by the scanner") {
             api.siteMap().issues().asSequence().map { Json.encodeToString(it.toSerializableForm()) }
         }
@@ -227,6 +377,211 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
                 interactions.joinToString("\n\n") {
                     Json.encodeToString(it.toSerializableForm())
                 }
+            }
+        }
+
+        mcpTool<StartActiveAudit>(
+            "Starts a Burp active scan (crawl + audit) for the target URL. " +
+            "If scanDurationSeconds is provided, the scan stops automatically after that many seconds. " +
+            "If omitted, the scan keeps running until stop_active_audit is called. " +
+            "Returns an auditId that can be used with stop_active_audit. " +
+            "Use get_scanner_issues to retrieve findings."
+        ) {
+            validateScanDuration(scanDurationSeconds)
+            val target = parseFocusedAuditTarget(targetUrl)
+            val allowed = runBlocking {
+                HttpRequestSecurity.checkAuditPermission(
+                    target.host, target.port, config, api
+                )
+            }
+            if (!allowed) {
+                api.logging().logToOutput("MCP start_active_audit denied for $targetUrl")
+                return@mcpTool "Active scan denied for $targetUrl. Approve the target in the consent dialog or add it to Auto-Approved HTTP Targets."
+            }
+
+            api.logging().logToOutput("MCP start_active_audit: starting active audit for $targetUrl")
+            val scopeCleanup = includeInScopeIfNeeded(api, targetUrl)
+            var crawl: burp.api.montoya.scanner.Crawl? = null
+            var audit: Audit? = null
+            var auditId: String? = null
+
+            try {
+                val crawlConfig = CrawlConfiguration.crawlConfiguration(targetUrl)
+                val activeCrawl = api.scanner().startCrawl(crawlConfig)
+                crawl = activeCrawl
+                api.logging().logToOutput("MCP start_active_audit: crawl started for $targetUrl")
+
+                val auditConfig = AuditConfiguration.auditConfiguration(
+                    BuiltInAuditConfiguration.LEGACY_ACTIVE_AUDIT_CHECKS
+                )
+                val activeAudit = api.scanner().startAudit(auditConfig)
+                audit = activeAudit
+                api.logging().logToOutput("MCP start_active_audit: audit started for $targetUrl")
+                activeAudit.addRequest(HttpRequest.httpRequestFromUrl(targetUrl))
+                api.logging().logToOutput("MCP start_active_audit: added initial audit request for $targetUrl")
+
+                val seen = mutableSetOf<String>()
+                val pollIntervalMs = 2000L
+                val deadlineNanos = scanDurationSeconds?.let { System.nanoTime() + it.toLong() * 1_000_000_000L }
+
+                val pollingThread = Thread {
+                    while (!Thread.currentThread().isInterrupted) {
+                        val sleepMillis = deadlineNanos?.let { deadline ->
+                            val remainingNanos = deadline - System.nanoTime()
+                            if (remainingNanos <= 0L) {
+                                api.logging().logToOutput(
+                                    "MCP start_active_audit: scan duration reached (${scanDurationSeconds} seconds)"
+                                )
+                                val timeoutAuditId = auditId
+                                if (timeoutAuditId != null) {
+                                    val stopMessage = auditRegistry.stopById(
+                                        timeoutAuditId,
+                                        interruptPollingThread = false
+                                    )
+                                    if (stopMessage != null) {
+                                        api.logging().logToOutput("MCP start_active_audit: $stopMessage")
+                                    }
+                                }
+                                return@Thread
+                            }
+                            minOf(pollIntervalMs, maxOf(1L, remainingNanos / 1_000_000L))
+                        } ?: pollIntervalMs
+
+                        try {
+                            Thread.sleep(sleepMillis)
+                            addMatchingResponsesToAudit(
+                                audit = activeAudit,
+                                requestResponses = api.siteMap().requestResponses(),
+                                target = target,
+                                seen = seen,
+                                logging = api.logging(),
+                            )
+                        } catch (_: InterruptedException) {
+                            Thread.currentThread().interrupt()
+                            return@Thread
+                        } catch (e: Exception) {
+                            api.logging().logToOutput("MCP start_active_audit: polling error: ${e.message}")
+                        }
+                    }
+                }.apply { isDaemon = true }
+
+                auditId = auditRegistry.register(
+                    crawl = activeCrawl,
+                    audit = activeAudit,
+                    pollingThread = pollingThread,
+                    cleanup = scopeCleanup,
+                )
+                pollingThread.start()
+
+                api.logging().logToOutput("MCP start_active_audit: registered as $auditId")
+                val stopMessage = if (scanDurationSeconds == null) {
+                    "Use stop_active_audit to stop."
+                } else {
+                    "It will stop automatically after $scanDurationSeconds seconds or sooner if stop_active_audit is used."
+                }
+                "Active scan started for $targetUrl (auditId: $auditId). Use get_scanner_issues to retrieve findings. $stopMessage"
+            } catch (e: Exception) {
+                if (auditId != null) {
+                    auditRegistry.stopById(auditId!!, interruptPollingThread = false)
+                } else {
+                    try {
+                        audit?.delete()
+                    } catch (_: Exception) {}
+                    try {
+                        crawl?.delete()
+                    } catch (_: Exception) {}
+                    try {
+                        scopeCleanup?.invoke()
+                    } catch (_: Exception) {}
+                }
+                throw e
+            }
+        }
+
+        mcpTool<StartActiveAuditForRequest>(
+            "Starts a focused Burp active audit for a specific HTTP request. " +
+            "Returns an auditId that can be used with stop_active_audit. " +
+            "Use get_scanner_issues to retrieve findings."
+        ) {
+            val target = parseFocusedAuditTarget(targetUrl)
+            validateFocusedAuditRequest(target, request)
+            val allowed = runBlocking {
+                HttpRequestSecurity.checkAuditPermission(
+                    target.host, target.port, config, api
+                )
+            }
+            if (!allowed) {
+                api.logging().logToOutput("MCP start_active_audit_for_request denied for $targetUrl")
+                return@mcpTool "Active scan denied for $targetUrl. Approve the target in the consent dialog or add it to Auto-Approved HTTP Targets."
+            }
+
+            api.logging().logToOutput("MCP start_active_audit_for_request: starting focused audit for $targetUrl")
+            val scopeCleanup = includeInScopeIfNeeded(api, targetUrl)
+            var audit: Audit? = null
+            var auditId: String? = null
+
+            try {
+                val auditConfig = AuditConfiguration.auditConfiguration(
+                    BuiltInAuditConfiguration.LEGACY_ACTIVE_AUDIT_CHECKS
+                )
+                val activeAudit = api.scanner().startAudit(auditConfig)
+                audit = activeAudit
+                api.logging().logToOutput("MCP start_active_audit_for_request: audit started for $targetUrl")
+
+                val service = HttpService.httpService(target.host, target.port, target.usesHttps)
+                val fixedRequest = request.replace("\r", "").replace("\n", "\r\n")
+                val httpRequest = HttpRequest.httpRequest(service, fixedRequest)
+
+                if (response != null) {
+                    val httpResponse = HttpResponse.httpResponse(response)
+                    val requestResponse = HttpRequestResponse.httpRequestResponse(httpRequest, httpResponse)
+                    activeAudit.addRequestResponse(requestResponse)
+                    api.logging().logToOutput("MCP start_active_audit_for_request: injected request-response for $targetUrl")
+                } else {
+                    activeAudit.addRequest(httpRequest)
+                    api.logging().logToOutput("MCP start_active_audit_for_request: injected request for $targetUrl")
+                }
+
+                auditId = auditRegistry.register(audit = activeAudit, cleanup = scopeCleanup)
+                api.logging().logToOutput("MCP start_active_audit_for_request: registered as $auditId")
+                "Focused active audit started for $targetUrl (auditId: $auditId). Use get_scanner_issues to retrieve findings. Use stop_active_audit to stop."
+            } catch (e: Exception) {
+                if (auditId != null) {
+                    auditRegistry.stopById(auditId!!, interruptPollingThread = false)
+                } else {
+                    try {
+                        audit?.delete()
+                    } catch (_: Exception) {}
+                    try {
+                        scopeCleanup?.invoke()
+                    } catch (_: Exception) {}
+                }
+                throw e
+            }
+        }
+
+        mcpTool<StopActiveAudit>(
+            "Stops running active audits started via MCP. " +
+            "With no auditId, stops all. With an auditId, stops only that audit."
+        ) {
+            if (auditId != null) {
+                val message = auditRegistry.stopById(auditId)
+                if (message != null) {
+                    api.logging().logToOutput("MCP stop_active_audit: $message")
+                    message
+                } else {
+                    api.logging().logToOutput("MCP stop_active_audit: $auditId not found")
+                    "Audit $auditId not found"
+                }
+            } else {
+                val result = auditRegistry.stopAll()
+                val message = if (result.failed > 0) {
+                    "Stopped ${result.total} audit(s); ${result.failed} failed: ${result.errors.joinToString(", ")}"
+                } else {
+                    "Stopped ${result.total} audit(s)"
+                }
+                api.logging().logToOutput("MCP stop_active_audit: $message")
+                message
             }
         }
     }
@@ -426,4 +781,22 @@ data class GenerateCollaboratorPayload(
 @Serializable
 data class GetCollaboratorInteractions(
     val payloadId: String? = null
+)
+
+@Serializable
+data class StartActiveAudit(
+    val targetUrl: String,
+    val scanDurationSeconds: Int? = null
+)
+
+@Serializable
+data class StartActiveAuditForRequest(
+    val targetUrl: String,
+    val request: String,
+    val response: String? = null
+)
+
+@Serializable
+data class StopActiveAudit(
+    val auditId: String? = null
 )

--- a/src/test/kotlin/net/portswigger/mcp/security/AuditSwingUserApprovalHandlerTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/security/AuditSwingUserApprovalHandlerTest.kt
@@ -1,0 +1,99 @@
+package net.portswigger.mcp.security
+
+import burp.api.montoya.MontoyaApi
+import burp.api.montoya.logging.Logging
+import burp.api.montoya.persistence.PersistedObject
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import net.portswigger.mcp.config.McpConfig
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AuditApprovalSecurityTest {
+
+    private lateinit var persistedObject: PersistedObject
+    private lateinit var config: McpConfig
+    private lateinit var mockLogging: Logging
+    private lateinit var storage: MutableMap<String, Any>
+
+    @BeforeEach
+    fun setup() {
+        storage = mutableMapOf(
+            "_autoApproveTargets" to "",
+            "requireHttpRequestApproval" to true
+        )
+        persistedObject = mockk<PersistedObject>().apply {
+            every { getBoolean(any()) } answers { storage[firstArg()] as? Boolean ?: false }
+            every { getString(any()) } answers { storage[firstArg()] as? String ?: "" }
+            every { getInteger(any()) } answers { storage[firstArg()] as? Int ?: 0 }
+            every { setBoolean(any(), any()) } answers { storage[firstArg()] = secondArg<Boolean>() }
+            every { setString(any(), any()) } answers { storage[firstArg()] = secondArg<String>() }
+            every { setInteger(any(), any()) } answers { storage[firstArg()] = secondArg<Int>() }
+        }
+        mockLogging = mockk<Logging>().apply {
+            every { logToError(any<String>()) } returns Unit
+        }
+        config = McpConfig(persistedObject, mockLogging)
+    }
+
+    @Test
+    fun `checkAuditPermission returns true when approval is disabled`() = runBlocking {
+        storage["requireHttpRequestApproval"] = false
+        val result = HttpRequestSecurity.checkAuditPermission("example.com", 443, config)
+        assertTrue(result)
+    }
+
+    @Test
+    fun `checkAuditPermission returns true when host is auto-approved`() = runBlocking {
+        config.addAutoApproveTarget("example.com")
+        val result = HttpRequestSecurity.checkAuditPermission("example.com", 443, config)
+        assertTrue(result)
+    }
+
+    @Test
+    fun `checkAuditPermission returns true when host port is auto-approved`() = runBlocking {
+        config.addAutoApproveTarget("example.com:8080")
+        val result = HttpRequestSecurity.checkAuditPermission("example.com", 8080, config)
+        assertTrue(result)
+    }
+
+    @Test
+    fun `checkAuditPermission delegates to auditApprovalHandler when not auto-approved`() = runBlocking {
+        val mockHandler = mockk<UserApprovalHandler>()
+        coEvery { mockHandler.requestApproval("example.com", 443, config, null, null) } returns false
+
+        val original = HttpRequestSecurity.auditApprovalHandler
+        try {
+            HttpRequestSecurity.auditApprovalHandler = mockHandler
+            val result = HttpRequestSecurity.checkAuditPermission("example.com", 443, config)
+            assertFalse(result)
+        } finally {
+            HttpRequestSecurity.auditApprovalHandler = original
+        }
+    }
+
+    @Test
+    fun `checkAuditPermission uses auditApprovalHandler not approvalHandler`() = runBlocking {
+        val mockAuditHandler = mockk<UserApprovalHandler>()
+        val mockHttpHandler = mockk<UserApprovalHandler>()
+        coEvery { mockAuditHandler.requestApproval("target.com", 443, config, null, null) } returns true
+        coEvery { mockHttpHandler.requestApproval("target.com", 443, config, null, null) } returns false
+
+        val originalAudit = HttpRequestSecurity.auditApprovalHandler
+        val originalHttp = HttpRequestSecurity.approvalHandler
+        try {
+            HttpRequestSecurity.auditApprovalHandler = mockAuditHandler
+            HttpRequestSecurity.approvalHandler = mockHttpHandler
+            val result = HttpRequestSecurity.checkAuditPermission("target.com", 443, config)
+            assertTrue(result)
+        } finally {
+            HttpRequestSecurity.auditApprovalHandler = originalAudit
+            HttpRequestSecurity.approvalHandler = originalHttp
+        }
+    }
+}

--- a/src/test/kotlin/net/portswigger/mcp/tools/ActiveAuditRegistryTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/ActiveAuditRegistryTest.kt
@@ -1,0 +1,184 @@
+package net.portswigger.mcp.tools
+
+import burp.api.montoya.scanner.Crawl
+import burp.api.montoya.scanner.audit.Audit
+import io.mockk.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ActiveAuditRegistryTest {
+
+    private val registry = ActiveAuditRegistry()
+
+    @BeforeEach
+    fun setup() {
+        registry.clear()
+    }
+
+    @Test
+    fun `register returns incrementing IDs`() {
+        val audit1 = mockk<Audit>(relaxed = true)
+        val audit2 = mockk<Audit>(relaxed = true)
+
+        val id1 = registry.register(audit = audit1)
+        val id2 = registry.register(audit = audit2)
+
+        assertEquals("audit-1", id1)
+        assertEquals("audit-2", id2)
+    }
+
+    @Test
+    fun `register with crawl stores both`() {
+        val crawl = mockk<Crawl>(relaxed = true)
+        val audit = mockk<Audit>(relaxed = true)
+
+        val id = registry.register(crawl = crawl, audit = audit)
+        assertNotNull(id)
+    }
+
+    @Test
+    fun `stopById runs cleanup callback`() {
+        val audit = mockk<Audit>(relaxed = true)
+        var cleanedUp = false
+
+        val id = registry.register(
+            audit = audit,
+            cleanup = { cleanedUp = true }
+        )
+
+        registry.stopById(id)
+
+        assertTrue(cleanedUp)
+    }
+
+    @Test
+    fun `stopAll deletes all tasks and interrupts threads`() {
+        val crawl = mockk<Crawl>(relaxed = true)
+        val audit1 = mockk<Audit>(relaxed = true)
+        val audit2 = mockk<Audit>(relaxed = true)
+        val thread = mockk<Thread>(relaxed = true)
+
+        registry.register(crawl = crawl, audit = audit1, pollingThread = thread)
+        registry.register(audit = audit2)
+
+        val result = registry.stopAll()
+
+        assertEquals(2, result.total)
+        assertEquals(0, result.failed)
+        verify { crawl.delete() }
+        verify { audit1.delete() }
+        verify { audit2.delete() }
+        verify { thread.interrupt() }
+    }
+
+    @Test
+    fun `stopAll on empty registry returns zero`() {
+        val result = registry.stopAll()
+        assertEquals(0, result.total)
+    }
+
+    @Test
+    fun `stopById deletes specific task and returns message`() {
+        val audit1 = mockk<Audit>(relaxed = true)
+        val audit2 = mockk<Audit>(relaxed = true)
+
+        val id1 = registry.register(audit = audit1)
+        registry.register(audit = audit2)
+
+        val result = registry.stopById(id1)
+
+        assertNotNull(result)
+        assertTrue(result!!.contains("Stopped"))
+        verify { audit1.delete() }
+        verify(exactly = 0) { audit2.delete() }
+    }
+
+    @Test
+    fun `stopById with unknown ID returns null`() {
+        val audit = mockk<Audit>(relaxed = true)
+        registry.register(audit = audit)
+
+        val result = registry.stopById("audit-999")
+
+        assertNull(result)
+        verify(exactly = 0) { audit.delete() }
+    }
+
+    @Test
+    fun `stopById with polling thread interrupts it`() {
+        val audit = mockk<Audit>(relaxed = true)
+        val thread = mockk<Thread>(relaxed = true)
+
+        val id = registry.register(audit = audit, pollingThread = thread)
+        registry.stopById(id)
+
+        verify { thread.interrupt() }
+    }
+
+    @Test
+    fun `stopAll clears registry`() {
+        val audit = mockk<Audit>(relaxed = true)
+        registry.register(audit = audit)
+
+        registry.stopAll()
+        val result = registry.stopAll()
+
+        assertEquals(0, result.total)
+    }
+
+    @Test
+    fun `stopById removes entry from registry`() {
+        val audit = mockk<Audit>(relaxed = true)
+        val id = registry.register(audit = audit)
+
+        assertNotNull(registry.stopById(id))
+        assertNull(registry.stopById(id))
+    }
+
+    @Test
+    fun `stopAll continues when delete throws and reports failures`() {
+        val audit1 = mockk<Audit>(relaxed = true)
+        val audit2 = mockk<Audit>(relaxed = true)
+
+        every { audit1.delete() } throws RuntimeException("delete failed")
+
+        registry.register(audit = audit1)
+        registry.register(audit = audit2)
+
+        val result = registry.stopAll()
+
+        assertEquals(2, result.total)
+        assertEquals(1, result.failed)
+        assertTrue(result.errors.any { it.contains("delete failed") })
+        verify { audit2.delete() }
+    }
+
+    @Test
+    fun `stopById returns failure message when delete throws`() {
+        val audit = mockk<Audit>(relaxed = true)
+        every { audit.delete() } throws RuntimeException("delete failed")
+
+        val id = registry.register(audit = audit)
+        val result = registry.stopById(id)
+
+        assertNotNull(result)
+        assertTrue(result!!.contains("failed"))
+    }
+
+    @Test
+    fun `stopAll reports cleanup failures`() {
+        val audit = mockk<Audit>(relaxed = true)
+
+        registry.register(
+            audit = audit,
+            cleanup = { throw RuntimeException("cleanup failed") }
+        )
+
+        val result = registry.stopAll()
+
+        assertEquals(1, result.total)
+        assertEquals(1, result.failed)
+        assertTrue(result.errors.any { it.contains("cleanup failed") })
+    }
+}

--- a/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
@@ -4,6 +4,8 @@ import burp.api.montoya.MontoyaApi
 import burp.api.montoya.burpsuite.TaskExecutionEngine
 import burp.api.montoya.collaborator.*
 import burp.api.montoya.core.BurpSuiteEdition
+import burp.api.montoya.scanner.AuditConfiguration
+import burp.api.montoya.scanner.CrawlConfiguration
 import burp.api.montoya.core.ByteArray
 import burp.api.montoya.http.Http
 import burp.api.montoya.http.HttpMode
@@ -125,6 +127,23 @@ class ToolsKtTest {
                 every { it.port() } returns port
                 every { it.secure() } returns secure
             }
+        }
+    }
+
+    private fun mockSiteMapRequestResponse(
+        url: String,
+        method: String = "GET",
+    ): burp.api.montoya.http.message.HttpRequestResponse {
+        val request = mockk<burp.api.montoya.http.message.requests.HttpRequest>()
+        every { request.url() } returns url
+        every { request.method() } returns method
+
+        val response = mockk<burp.api.montoya.http.message.responses.HttpResponse>()
+        every { response.toString() } returns "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nok"
+
+        return mockk {
+            every { request() } returns request
+            every { response() } returns response
         }
     }
     
@@ -981,6 +1000,293 @@ class ToolsKtTest {
                 delay(100)
                 result.expectTextContent("No interactions detected")
             }
+        }
+    }
+
+    @Nested
+    inner class ActiveAuditToolsTests {
+        private val scanner = mockk<burp.api.montoya.scanner.Scanner>(relaxed = true)
+
+        @BeforeEach
+        fun setupProfessional() {
+            val burpSuite = mockk<burp.api.montoya.burpsuite.BurpSuite>()
+            val version = mockk<burp.api.montoya.core.Version>()
+            every { api.burpSuite() } returns burpSuite
+            every { burpSuite.version() } returns version
+            every { version.edition() } returns BurpSuiteEdition.PROFESSIONAL
+            every { burpSuite.taskExecutionEngine() } returns mockk(relaxed = true)
+            every { burpSuite.exportProjectOptionsAsJson() } returns "{}"
+            every { burpSuite.exportUserOptionsAsJson() } returns "{}"
+            every { burpSuite.importProjectOptionsFromJson(any()) } just runs
+            every { burpSuite.importUserOptionsFromJson(any()) } just runs
+            every { api.scanner() } returns scanner
+
+            serverManager.stop {}
+            serverStarted = false
+            serverManager.start(config) { state ->
+                if (state is ServerState.Running) serverStarted = true
+            }
+
+            runBlocking {
+                var attempts = 0
+                while (!serverStarted && attempts < 30) {
+                    delay(100)
+                    attempts++
+                }
+                if (!serverStarted) throw IllegalStateException("Server failed to start after timeout")
+                client.connectToServer("http://127.0.0.1:${testPort}")
+            }
+        }
+
+        @Test
+        fun `stop_active_audit tool should be registered in professional edition`() {
+            runBlocking {
+                val tools = client.listTools()
+                assertTrue(tools.any { it.name == "stop_active_audit" })
+            }
+        }
+
+        @Test
+        fun `start_active_audit should make scanDurationSeconds optional`() {
+            runBlocking {
+                val tool = client.listTools().single { it.name == "start_active_audit" }
+                assertFalse(tool.inputSchema.required?.contains("scanDurationSeconds") ?: false)
+            }
+        }
+
+        @Test
+        fun `stop all audits should return count`() {
+            runBlocking {
+                val result = client.callTool("stop_active_audit", emptyMap())
+                delay(100)
+                val text = result.expectTextContent()
+                assertTrue(text.contains("0"), "Should report 0 stopped when none running")
+            }
+        }
+
+        @Test
+        fun `stop with invalid audit ID should return not found`() {
+            runBlocking {
+                val result = client.callTool(
+                    "stop_active_audit", mapOf(
+                        "auditId" to "audit-999"
+                    )
+                )
+                delay(100)
+                val text = result.expectTextContent()
+                assertTrue(text.contains("not found"), "Should report not found for invalid ID")
+            }
+        }
+
+        @Test
+        fun `start then stop by ID should delete the task`() {
+            val mockCrawl = mockk<burp.api.montoya.scanner.Crawl>(relaxed = true)
+            val mockAudit = mockk<burp.api.montoya.scanner.audit.Audit>(relaxed = true)
+            val mockScope = mockk<burp.api.montoya.sitemap.SiteMap>(relaxed = true)
+            val mockScopeTarget = mockk<burp.api.montoya.scope.Scope>(relaxed = true)
+
+            every { scanner.startCrawl(any()) } returns mockCrawl
+            every { scanner.startAudit(any()) } returns mockAudit
+            every { api.siteMap() } returns mockScope
+            every { api.scope() } returns mockScopeTarget
+            every { mockScopeTarget.isInScope(any()) } returns false
+
+            mockkStatic(CrawlConfiguration::class)
+            mockkStatic(AuditConfiguration::class)
+            mockkStatic(HttpRequest::class)
+            every { CrawlConfiguration.crawlConfiguration(any<String>()) } returns mockk(relaxed = true)
+            every { AuditConfiguration.auditConfiguration(any()) } returns mockk(relaxed = true)
+            every { HttpRequest.httpRequestFromUrl(any<String>()) } returns mockk(relaxed = true)
+
+            runBlocking {
+                val startResult = client.callTool(
+                    "start_active_audit", mapOf(
+                        "targetUrl" to "https://example.com",
+                        "scanDurationSeconds" to 300
+                    )
+                )
+                delay(100)
+                val startText = startResult.expectTextContent()
+                assertTrue(startText.contains("auditId:"), "Should contain auditId")
+
+                val auditId = Regex("auditId: (audit-\\d+)").find(startText)!!.groupValues[1]
+
+                val stopResult = client.callTool(
+                    "stop_active_audit", mapOf(
+                        "auditId" to auditId
+                    )
+                )
+                delay(100)
+                val stopText = stopResult.expectTextContent()
+                assertTrue(stopText.contains("Stopped"), "Should confirm stopped")
+            }
+
+            verify { mockCrawl.delete() }
+            verify { mockAudit.delete() }
+            verify { mockScopeTarget.includeInScope("https://example.com") }
+            verify { mockScopeTarget.excludeFromScope("https://example.com") }
+
+            unmockkStatic(CrawlConfiguration::class)
+            unmockkStatic(AuditConfiguration::class)
+        }
+
+        @Test
+        fun `start_active_audit should reject non-positive scan duration`() {
+            runBlocking {
+                val result = client.callTool(
+                    "start_active_audit", mapOf(
+                        "targetUrl" to "https://example.com",
+                        "scanDurationSeconds" to 0
+                    )
+                )
+                delay(100)
+                assertTrue(result?.isError == true)
+                val text = result.expectTextContent()
+                assertTrue(text.contains("scanDurationSeconds must be greater than 0"))
+            }
+        }
+
+        @Test
+        fun `start_active_audit should only add site map items within target scheme host port and path scope`() {
+            val mockCrawl = mockk<burp.api.montoya.scanner.Crawl>(relaxed = true)
+            val mockAudit = mockk<burp.api.montoya.scanner.audit.Audit>(relaxed = true)
+            val mockSiteMap = mockk<burp.api.montoya.sitemap.SiteMap>(relaxed = true)
+            val mockScope = mockk<burp.api.montoya.scope.Scope>(relaxed = true)
+            val addedRequestResponses = mutableListOf<burp.api.montoya.http.message.HttpRequestResponse>()
+
+            every { scanner.startCrawl(any()) } returns mockCrawl
+            every { scanner.startAudit(any()) } returns mockAudit
+            every { api.siteMap() } returns mockSiteMap
+            every { api.scope() } returns mockScope
+            every { mockScope.isInScope(any()) } returns false
+            every { mockSiteMap.requestResponses() } returns listOf(
+                mockSiteMapRequestResponse("https://example.com/app"),
+                mockSiteMapRequestResponse("https://example.com/app/users"),
+                mockSiteMapRequestResponse("https://example.com/app2"),
+                mockSiteMapRequestResponse("https://example.com:8443/app/admin"),
+                mockSiteMapRequestResponse("http://example.com/app")
+            )
+            every { mockAudit.addRequestResponse(capture(addedRequestResponses)) } just runs
+
+            mockkStatic(CrawlConfiguration::class)
+            mockkStatic(AuditConfiguration::class)
+            every { CrawlConfiguration.crawlConfiguration(any<String>()) } returns mockk(relaxed = true)
+            every { AuditConfiguration.auditConfiguration(any()) } returns mockk(relaxed = true)
+            every { HttpRequest.httpRequestFromUrl(any<String>()) } returns mockk(relaxed = true)
+
+            runBlocking {
+                val startResult = client.callTool(
+                    "start_active_audit", mapOf(
+                        "targetUrl" to "https://example.com/app",
+                        "scanDurationSeconds" to 2
+                    )
+                )
+                delay(2400)
+                val startText = startResult.expectTextContent()
+                val auditId = Regex("auditId: (audit-\\d+)").find(startText)!!.groupValues[1]
+
+                val stopResult = client.callTool(
+                    "stop_active_audit", mapOf(
+                        "auditId" to auditId
+                    )
+                )
+                delay(100)
+                stopResult.expectTextContent()
+            }
+
+            assertEquals(
+                setOf(
+                    "https://example.com/app",
+                    "https://example.com/app/users",
+                ),
+                addedRequestResponses.map { it.request().url() }.toSet()
+            )
+
+            unmockkStatic(CrawlConfiguration::class)
+            unmockkStatic(AuditConfiguration::class)
+        }
+
+        @Test
+        fun `start_active_audit should stop crawl and audit after timeout and roll back scope`() {
+            val mockCrawl = mockk<burp.api.montoya.scanner.Crawl>(relaxed = true)
+            val mockAudit = mockk<burp.api.montoya.scanner.audit.Audit>(relaxed = true)
+            val mockSiteMap = mockk<burp.api.montoya.sitemap.SiteMap>(relaxed = true)
+            val mockScope = mockk<burp.api.montoya.scope.Scope>(relaxed = true)
+
+            every { scanner.startCrawl(any()) } returns mockCrawl
+            every { scanner.startAudit(any()) } returns mockAudit
+            every { api.siteMap() } returns mockSiteMap
+            every { api.scope() } returns mockScope
+            every { mockScope.isInScope(any()) } returns false
+            every { mockSiteMap.requestResponses() } returns emptyList()
+
+            mockkStatic(CrawlConfiguration::class)
+            mockkStatic(AuditConfiguration::class)
+            every { CrawlConfiguration.crawlConfiguration(any<String>()) } returns mockk(relaxed = true)
+            every { AuditConfiguration.auditConfiguration(any()) } returns mockk(relaxed = true)
+            every { HttpRequest.httpRequestFromUrl(any<String>()) } returns mockk(relaxed = true)
+
+            try {
+                runBlocking {
+                    val startResult = client.callTool(
+                        "start_active_audit", mapOf(
+                            "targetUrl" to "https://example.com/app",
+                            "scanDurationSeconds" to 2
+                        )
+                    )
+                    delay(100)
+                    startResult.expectTextContent()
+                    delay(2400)
+                }
+
+                verify(timeout = 500) { mockAudit.delete() }
+                verify(timeout = 500) { mockCrawl.delete() }
+                verify { mockScope.includeInScope("https://example.com/app") }
+                verify(timeout = 500) { mockScope.excludeFromScope("https://example.com/app") }
+            } finally {
+                unmockkStatic(CrawlConfiguration::class)
+                unmockkStatic(AuditConfiguration::class)
+            }
+        }
+
+        @Test
+        fun `start_active_audit_for_request should roll back scope when stopped`() {
+            val mockAudit = mockk<burp.api.montoya.scanner.audit.Audit>(relaxed = true)
+            val mockScope = mockk<burp.api.montoya.scope.Scope>(relaxed = true)
+            val mockAuditRequest = mockk<HttpRequest>(relaxed = true)
+
+            every { scanner.startAudit(any()) } returns mockAudit
+            every { api.scope() } returns mockScope
+            every { mockScope.isInScope(any()) } returns false
+
+            mockkStatic(AuditConfiguration::class)
+            every { AuditConfiguration.auditConfiguration(any()) } returns mockk(relaxed = true)
+            every { HttpRequest.httpRequest(any(), any<String>()) } returns mockAuditRequest
+
+            runBlocking {
+                val startResult = client.callTool(
+                    "start_active_audit_for_request", mapOf(
+                        "targetUrl" to "https://example.com/app",
+                        "request" to "GET /app HTTP/1.1\r\nHost: example.com\r\n\r\n"
+                    )
+                )
+                delay(100)
+                val startText = startResult.expectTextContent()
+                val auditId = Regex("auditId: (audit-\\d+)").find(startText)!!.groupValues[1]
+
+                val stopResult = client.callTool(
+                    "stop_active_audit", mapOf(
+                        "auditId" to auditId
+                    )
+                )
+                delay(100)
+                stopResult.expectTextContent()
+            }
+
+            verify { mockScope.includeInScope("https://example.com/app") }
+            verify { mockScope.excludeFromScope("https://example.com/app") }
+
+            unmockkStatic(AuditConfiguration::class)
         }
     }
 


### PR DESCRIPTION
## Summary
- add `start_active_audit`, `start_active_audit_for_request`, and `stop_active_audit`
- reuse the existing HTTP approval whitelist for active audit prompts
- limit site map items added to the audit to the target scheme, host, resolved port, and path prefix
- stop the crawl and audit automatically when `scanDurationSeconds` is provided
- add temporary scope entries only when needed and roll them back when the scan stops
- add tests for approval routing, registry cleanup, timeout handling, scope rollback, and target filtering

## Testing
- `./gradlew test --tests 'net.portswigger.mcp.tools.ToolsKtTest' --tests 'net.portswigger.mcp.tools.ActiveAuditRegistryTest' --tests 'net.portswigger.mcp.security.AuditApprovalSecurityTest'`

Addresses #50.
