### PR TITLE
Add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "mcp-server",
+  "version": "0.1.0",
+  "description": "MCP Server for Burp",
+  "author": {
+    "name": "PortSwigger",
+    "url": "https://github.com/PortSwigger"
+  },
+  "homepage": "https://github.com/PortSwigger/mcp-server",
+  "repository": "https://github.com/PortSwigger/mcp-server",
+  "keywords": [
+    "mcp",
+    "codex"
+  ],
+  "mcpServers": "./.mcp.json"
+}

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,22 @@
+name: Codex Plugin Quality Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Codex plugin scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "mcp-server": {
+      "command": "npx",
+      "args": [
+        "PortSwigger-mcp-server"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds a `.codex-plugin/plugin.json` manifest so mcp-server can be installed as a Codex CLI plugin.

This adds the basic plugin structure including:
- `.codex-plugin/plugin.json` — Plugin manifest with metadata
- `.mcp.json` — MCP server reference
- `.github/workflows/codex-plugin-scanner.yml` — CI quality gate

The scanner validates your plugin manifest on every push/PR.
