### PR TITLE
Add manual client configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,47 +147,19 @@ copilot mcp list
 copilot mcp get burp
 ```
 
-#### GitHub Copilot in VS Code
-
-VS Code can connect directly to the Burp SSE endpoint using `.vscode/mcp.json`:
-
-```json
-{
-  "servers": {
-    "burp": {
-      "type": "sse",
-      "url": "http://127.0.0.1:9876"
-    }
-  }
-}
-```
-
-You can also add the same configuration to your user profile with the VS Code CLI:
-
-```bash
-code --add-mcp '{"name":"burp","type":"sse","url":"http://127.0.0.1:9876"}'
-```
-
 #### Codex CLI
 
 Codex CLI works well with the packaged stdio proxy server. You can add the Burp proxy with:
 
 ```bash
-codex -c model_reasoning_effort='"high"' mcp add burp -- java -jar /path/to/proxy/jar/mcp-proxy-all.jar --sse-url http://127.0.0.1:9876
+codex mcp add burp -- java -jar /path/to/mcp-proxy-all.jar --sse-url http://127.0.0.1:9876
 ```
 
 This adds a stdio MCP server entry that forwards requests to the Burp SSE endpoint.
 
 ### SSE MCP Server
 In order to use the SSE server directly you can just provide the url for the server in your client's configuration. Depending
-on your client and your configuration in the extension this may be with or without the `/sse` path.
-```
-http://127.0.0.1:9876
-```
-or
-```
-http://127.0.0.1:9876/sse
-```
+on your client and your configuration in the extension this may be without the `/sse` path (`http://127.0.0.1:9876`) or with the `/sse` path (`http://127.0.0.1:9876/sse`).
 
 ### Stdio MCP Proxy Server
 The source code for the proxy server can be found here: [MCP Proxy Server](https://github.com/PortSwigger/mcp-proxy)
@@ -198,13 +170,13 @@ passing requests to the SSE MCP server extension.
 If you want to use the Stdio proxy server you can use the extension's installer option to extract the proxy server jar.
 Once you have the jar you can add the following command and args to your client configuration:
 ```
-/path/to/packaged/burp/java -jar /path/to/proxy/jar/mcp-proxy-all.jar --sse-url http://127.0.0.1:9876
+/path/to/java -jar /path/to/mcp-proxy-all.jar --sse-url http://127.0.0.1:9876
 ```
 
 If you have issues discovering tools when using Codex CLI, explicitly setting `model_reasoning_effort` can help:
 
 ```
-codex -c model_reasoning_effort='"high"' mcp add burp -- java -jar /path/to/proxy/jar/mcp-proxy-all.jar --sse-url http://127.0.0.1:9876
+codex -c model_reasoning_effort='"high"' mcp add burp -- java -jar /path/to/mcp-proxy-all.jar --sse-url http://127.0.0.1:9876
 ```
 
 ### Creating / modifying tools

--- a/README.md
+++ b/README.md
@@ -109,6 +109,75 @@ The extension has an installer which will automatically configure the client set
 If you want to install the MCP server manually you can either use the extension's SSE server directly or the packaged
 Stdio proxy server.
 
+### Client configuration examples
+
+The examples below show how to configure some popular MCP clients to connect to Burp Suite.
+
+#### OpenCode
+
+OpenCode can connect directly to the Burp SSE endpoint using a remote MCP server definition.
+
+Add the following to `~/.config/opencode/opencode.json` or your project `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "burp": {
+      "type": "remote",
+      "url": "http://127.0.0.1:9876",
+      "enabled": true
+    }
+  }
+}
+```
+
+#### GitHub Copilot CLI
+
+GitHub Copilot CLI can connect directly to the Burp SSE endpoint:
+
+```bash
+copilot mcp add --transport sse burp http://127.0.0.1:9876
+```
+
+You can verify the configuration with:
+
+```bash
+copilot mcp list
+copilot mcp get burp
+```
+
+#### GitHub Copilot in VS Code
+
+VS Code can connect directly to the Burp SSE endpoint using `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "burp": {
+      "type": "sse",
+      "url": "http://127.0.0.1:9876"
+    }
+  }
+}
+```
+
+You can also add the same configuration to your user profile with the VS Code CLI:
+
+```bash
+code --add-mcp '{"name":"burp","type":"sse","url":"http://127.0.0.1:9876"}'
+```
+
+#### Codex CLI
+
+Codex CLI works well with the packaged stdio proxy server. You can add the Burp proxy with:
+
+```bash
+codex -c model_reasoning_effort='"high"' mcp add burp -- java -jar /path/to/proxy/jar/mcp-proxy-all.jar --sse-url http://127.0.0.1:9876
+```
+
+This adds a stdio MCP server entry that forwards requests to the Burp SSE endpoint.
+
 ### SSE MCP Server
 In order to use the SSE server directly you can just provide the url for the server in your client's configuration. Depending
 on your client and your configuration in the extension this may be with or without the `/sse` path.
@@ -130,6 +199,12 @@ If you want to use the Stdio proxy server you can use the extension's installer 
 Once you have the jar you can add the following command and args to your client configuration:
 ```
 /path/to/packaged/burp/java -jar /path/to/proxy/jar/mcp-proxy-all.jar --sse-url http://127.0.0.1:9876
+```
+
+If you have issues discovering tools when using Codex CLI, explicitly setting `model_reasoning_effort` can help:
+
+```
+codex -c model_reasoning_effort='"high"' mcp add burp -- java -jar /path/to/proxy/jar/mcp-proxy-all.jar --sse-url http://127.0.0.1:9876
 ```
 
 ### Creating / modifying tools


### PR DESCRIPTION
## Why
The current README mostly documents Claude Desktop plus generic manual installation notes. In practice, users are also trying to connect Burp MCP to other agent clients, but the exact working configuration differs depending on whether the client supports SSE directly or needs a stdio proxy.

This change adds concrete, copy-pasteable examples for clients that were tested and confirmed working, so users do not need to infer the correct configuration from the Claude-specific instructions.

## Scope
This PR is documentation-only:
- no runtime changes
- no extension UI changes
- no new installer integrations

I intentionally left out unverified client examples to keep the guidance accurate and minimal.

## Related issues
- Helps with [#46](https://github.com/PortSwigger/mcp-server/issues/46) by adding concrete MCP client configuration examples.
- Related to [#38](https://github.com/PortSwigger/mcp-server/issues/38), which asks for clearer non-Claude-Desktop setup guidance.
- May help users hitting [#42](https://github.com/PortSwigger/mcp-server/issues/42) by clarifying direct SSE endpoint options.

## Notes
- OpenCode and GitHub Copilot CLI can connect directly to the Burp SSE endpoint.
- Codex CLI works well through the packaged stdio proxy.
- Depending on the client, the Burp endpoint may need to be configured as either:
  - `http://127.0.0.1:9876`
  - `http://127.0.0.1:9876/sse`

## Manual verification
- verified OpenCode against a local Burp MCP server
- verified GitHub Copilot CLI against a local Burp MCP server
- verified Codex CLI against a local Burp MCP server via `mcp-proxy-all.jar`
