### PR TITLE
Add OpenCode installer provider

### DIFF
--- a/src/main/kotlin/net/portswigger/mcp/ExtensionBase.kt
+++ b/src/main/kotlin/net/portswigger/mcp/ExtensionBase.kt
@@ -6,6 +6,7 @@ import net.portswigger.mcp.config.ConfigUi
 import net.portswigger.mcp.config.McpConfig
 import net.portswigger.mcp.providers.ClaudeDesktopProvider
 import net.portswigger.mcp.providers.ManualProxyInstallerProvider
+import net.portswigger.mcp.providers.OpenCodeProvider
 import net.portswigger.mcp.providers.ProxyJarManager
 
 @Suppress("unused")
@@ -22,6 +23,7 @@ class ExtensionBase : BurpExtension {
         val configUi = ConfigUi(
             config = config, providers = listOf(
                 ClaudeDesktopProvider(api.logging(), proxyJarManager),
+                OpenCodeProvider(api.logging()),
                 ManualProxyInstallerProvider(api.logging(), proxyJarManager),
             )
         )

--- a/src/main/kotlin/net/portswigger/mcp/providers/Provider.kt
+++ b/src/main/kotlin/net/portswigger/mcp/providers/Provider.kt
@@ -9,6 +9,7 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import javax.swing.JFileChooser
 import kotlin.io.path.exists
+import kotlin.io.path.createDirectories
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
 
@@ -17,6 +18,60 @@ interface Provider {
     val installButtonText: String
     val confirmationText: String?
     fun install(config: McpConfig): String?
+}
+
+class OpenCodeProvider(
+    private val logging: Logging,
+    private val userHome: Path = Path.of(System.getProperty("user.home"))
+) : Provider {
+
+    private val schemaKey = "\$schema"
+    private val configFileName = "opencode.json"
+    private val serverName = "burp"
+
+    override val name = "OpenCode"
+    override val installButtonText = "Install to $name"
+    override val confirmationText =
+        "Install to $name?\nThis will create or update $name's global MCP configuration ($configFileName)."
+
+    override fun install(config: McpConfig): String {
+        val path = configFilePath()
+        path.parent.createDirectories()
+
+        val content = if (path.exists()) {
+            Json.parseToJsonElement(path.readText()).jsonObject.toMutableMap()
+        } else {
+            mutableMapOf(
+                schemaKey to JsonPrimitive("https://opencode.ai/config.json"),
+                "mcp" to buildJsonObject {}
+            )
+        }
+
+        val burpServerConfig = buildJsonObject {
+            put("type", JsonPrimitive("remote"))
+            put("url", JsonPrimitive("http://${config.host}:${config.port}"))
+            put("enabled", JsonPrimitive(true))
+        }
+
+        val mcp = content["mcp"]?.jsonObject?.toMutableMap() ?: mutableMapOf()
+        mcp[serverName] = burpServerConfig
+        content["mcp"] = JsonObject(mcp)
+        content.putIfAbsent(schemaKey, JsonPrimitive("https://opencode.ai/config.json"))
+
+        val json = Json {
+            prettyPrint = true
+            encodeDefaults = true
+        }
+        path.writeText(json.encodeToString(JsonObject.serializer(), JsonObject(content)))
+
+        logging.logToOutput("Installed Burp MCP Server to OpenCode config")
+
+        return "Installation successful. Please restart $name if it is currently running."
+    }
+
+    private fun configFilePath(): Path {
+        return userHome.resolve(".config").resolve("opencode").resolve(configFileName)
+    }
 }
 
 class ClaudeDesktopProvider(private val logging: Logging, private val proxyJarManager: ProxyJarManager) : Provider {

--- a/src/test/kotlin/net/portswigger/mcp/providers/OpenCodeProviderTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/providers/OpenCodeProviderTest.kt
@@ -1,0 +1,127 @@
+package net.portswigger.mcp.providers
+
+import burp.api.montoya.logging.Logging
+import burp.api.montoya.persistence.PersistedObject
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import net.portswigger.mcp.config.McpConfig
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class OpenCodeProviderTest {
+
+    private val schemaKey = "\$schema"
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var logging: Logging
+    private lateinit var config: McpConfig
+
+    @BeforeEach
+    fun setup() {
+        val storage = mutableMapOf<String, Any>()
+
+        val persistedObject = mockk<PersistedObject>().apply {
+            every { getBoolean(any()) } answers {
+                val key = firstArg<String>()
+                storage[key] as? Boolean ?: when (key) {
+                    "enabled" -> true
+                    else -> false
+                }
+            }
+            every { getString(any()) } answers {
+                val key = firstArg<String>()
+                storage[key] as? String ?: when (key) {
+                    "host" -> "127.0.0.1"
+                    else -> ""
+                }
+            }
+            every { getInteger(any()) } answers {
+                val key = firstArg<String>()
+                storage[key] as? Int ?: when (key) {
+                    "port" -> 9876
+                    else -> 0
+                }
+            }
+            every { setBoolean(any(), any()) } answers {
+                storage[firstArg()] = secondArg<Boolean>()
+            }
+            every { setString(any(), any()) } answers {
+                storage[firstArg()] = secondArg<String>()
+            }
+            every { setInteger(any(), any()) } answers {
+                storage[firstArg()] = secondArg<Int>()
+            }
+        }
+
+        logging = mockk<Logging>().apply {
+            every { logToOutput(any<String>()) } returns Unit
+            every { logToError(any<String>()) } returns Unit
+        }
+
+        config = McpConfig(persistedObject, logging)
+    }
+
+    @Test
+    fun `install should create OpenCode config when missing`() {
+        val provider = OpenCodeProvider(logging, tempDir)
+
+        val result = provider.install(config)
+
+        val configPath = tempDir.resolve(".config").resolve("opencode").resolve("opencode.json")
+        assertTrue(configPath.toFile().exists())
+        assertEquals("Installation successful. Please restart OpenCode if it is currently running.", result)
+
+        val json = Json.parseToJsonElement(configPath.toFile().readText()).jsonObject
+        assertEquals("https://opencode.ai/config.json", json[schemaKey]!!.jsonPrimitive.content)
+        assertEquals("remote", json["mcp"]!!.jsonObject["burp"]!!.jsonObject["type"]!!.jsonPrimitive.content)
+        assertEquals("http://127.0.0.1:9876", json["mcp"]!!.jsonObject["burp"]!!.jsonObject["url"]!!.jsonPrimitive.content)
+        assertTrue(json["mcp"]!!.jsonObject["burp"]!!.jsonObject["enabled"]!!.jsonPrimitive.boolean)
+        verify { logging.logToOutput("Installed Burp MCP Server to OpenCode config") }
+    }
+
+    @Test
+    fun `install should preserve existing config and replace burp entry`() {
+        val configPath = tempDir.resolve(".config").resolve("opencode").resolve("opencode.json")
+        configPath.parent.toFile().mkdirs()
+        configPath.toFile().writeText(
+            """
+            {
+              "${'$'}schema": "https://opencode.ai/config.json",
+              "mcp": {
+                "jira": {
+                  "type": "local",
+                  "command": ["uvx", "mcp-atlassian"],
+                  "enabled": true
+                },
+                "burp": {
+                  "type": "local",
+                  "command": ["java", "-jar", "/tmp/old.jar"],
+                  "enabled": false
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val provider = OpenCodeProvider(logging, tempDir)
+
+        provider.install(config)
+
+        val json = Json.parseToJsonElement(configPath.toFile().readText()).jsonObject
+        assertEquals("local", json["mcp"]!!.jsonObject["jira"]!!.jsonObject["type"]!!.jsonPrimitive.content)
+        assertEquals("remote", json["mcp"]!!.jsonObject["burp"]!!.jsonObject["type"]!!.jsonPrimitive.content)
+        assertEquals("http://127.0.0.1:9876", json["mcp"]!!.jsonObject["burp"]!!.jsonObject["url"]!!.jsonPrimitive.content)
+        assertTrue(json["mcp"]!!.jsonObject["burp"]!!.jsonObject["enabled"]!!.jsonPrimitive.boolean)
+    }
+}


### PR DESCRIPTION
## Why
The Burp MCP extension already provides a one-click installer for Claude Desktop, but other agent clients currently require users to manually edit their configuration files.

OpenCode was verified as a working client in the docs PR, and it has a stable JSON configuration format that is straightforward to update automatically. Adding a dedicated installer button reduces setup friction and makes Burp's MCP integration feel more complete for users working outside Claude Desktop.

## What changed
- add a new `OpenCodeProvider` installer
- register an `Install to OpenCode` button in the MCP installation panel
- create or update `~/.config/opencode/opencode.json`
- add or replace the `mcp.burp` entry with a remote server configuration pointing to the Burp MCP endpoint
- preserve unrelated OpenCode config entries when updating the file
- add tests covering config creation and merge behavior

## Scope
This PR only adds automatic installation for OpenCode.

It does not:
- add installers for other clients
- change the MCP server runtime behavior
- modify the existing Claude Desktop installer flow

## Related issues
- Builds on the client setup work documented in [#83](https://github.com/PortSwigger/mcp-server/pull/83).
- Helps with [#46](https://github.com/PortSwigger/mcp-server/issues/46) by making one tested client easier to configure.
- Related to [#38](https://github.com/PortSwigger/mcp-server/issues/38), which asks for clearer setup outside the Claude Desktop happy path.
- May help users hitting [#42](https://github.com/PortSwigger/mcp-server/issues/42) by reducing manual config mistakes around the Burp endpoint.

## Manual verification
- verified that OpenCode works against a local Burp MCP server
- verified installer output writes a valid `opencode.json`
- verified existing OpenCode config entries are preserved while `mcp.burp` is updated

## Tests
- added focused tests for OpenCode config creation
- added focused tests for OpenCode config merge/replacement
- ran `./gradlew test`
