### PR TITLE
Duplicate proxy history tools to retrieve requests from Organizer.

### DIFF
--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -255,6 +255,30 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
             .map { truncateIfNeeded(Json.encodeToString(it.toSerializableForm())) }
     }
 
+    mcpPaginatedTool<GetOrganizerRequests>("Displays items within the Organizer tab") {
+        val allowed = runBlocking {
+            checkHistoryPermissionOrDeny(HistoryAccessType.HTTP_HISTORY, config, api, "HTTP history")
+        }
+        if (!allowed) {
+            return@mcpPaginatedTool sequenceOf("HTTP history access denied by Burp Suite")
+        }
+
+        api.organizer().items().asSequence().map { truncateIfNeeded(Json.encodeToString(it.toSerializableForm())) }
+    }
+
+    mcpPaginatedTool<GetOrganizerRequestsRegex>("Displays items matching a specified regex within the Organizer tab") {
+        val allowed = runBlocking {
+            checkHistoryPermissionOrDeny(HistoryAccessType.HTTP_HISTORY, config, api, "HTTP history")
+        }
+        if (!allowed) {
+            return@mcpPaginatedTool sequenceOf("HTTP history access denied by Burp Suite")
+        }
+
+        val compiledRegex = Pattern.compile(regex)
+        api.organizer().items { it.contains(compiledRegex) }.asSequence()
+            .map { truncateIfNeeded(Json.encodeToString(it.toSerializableForm())) }
+    }
+
     mcpPaginatedTool<GetProxyWebsocketHistory>("Displays items within the proxy WebSocket history") {
         val allowed = runBlocking {
             checkHistoryPermissionOrDeny(HistoryAccessType.WEBSOCKET_HISTORY, config, api, "WebSocket history")
@@ -410,6 +434,12 @@ data class GetProxyHttpHistory(override val count: Int, override val offset: Int
 
 @Serializable
 data class GetProxyHttpHistoryRegex(val regex: String, override val count: Int, override val offset: Int) : Paginated
+
+@Serializable
+data class GetOrganizerRequests(override val count: Int, override val offset: Int) : Paginated
+
+@Serializable
+data class GetOrganizerRequestsRegex(val regex: String, override val count: Int, override val offset: Int) : Paginated
 
 @Serializable
 data class GetProxyWebsocketHistory(override val count: Int, override val offset: Int) : Paginated


### PR DESCRIPTION
## Why

I often create requests manually in Repeater and the current tools don't offer a good way to export those requests. Because the Montoya API supports retrieving HTTP requests from organizer, this change allows export of non-proxy requests once they have been saved to Organizer. 

## Related issues

None

## Notes

The `OrganizerItem` type inherits from `HttpRequestResponse` so all logic here works identically to the HTTP Proxy retrieval tools. 

This change copied the existing tool code for the HTTP proxy retrieval and modified 2 lines per method to update the description and change the targeted method from `api.proxy().history()` to `api.organizer().items()`.

The added tools rely on the existing HTTP history permission for access.

It looks like the current tests for the proxy history just relate to pagination so I did not add additional tests.

## Manual verification

Built and verified manually calling the MCP server from Kiro.