### PR TITLE
Reject comma-injected hostnames in auto-approve list

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 group=net.portswigger
-version=1.1.2
+version=1.1.3
 description=Burp MCP Server Extension
 org.gradle.daemon=true
 org.gradle.parallel=true

--- a/src/main/kotlin/net/portswigger/mcp/config/McpConfig.kt
+++ b/src/main/kotlin/net/portswigger/mcp/config/McpConfig.kt
@@ -42,10 +42,6 @@ class McpConfig(storage: PersistedObject, private val logging: Logging) {
     private val targetsChangeListeners = CopyOnWriteArrayList<ListenerRegistration>()
     private val historyAccessChangeListeners = CopyOnWriteArrayList<ListenerRegistration>()
 
-    init {
-        migrateLegacyAutoApproveTargets()
-    }
-
     var autoApproveTargets: String
         get() = _autoApproveTargets
         set(value) {
@@ -54,6 +50,14 @@ class McpConfig(storage: PersistedObject, private val logging: Logging) {
                 notifyTargetsChanged()
             }
         }
+
+    init {
+        val current = getAutoApproveTargetsList()
+        val valid = current.filter { TargetValidation.isValidTarget(it) }
+        if (valid.size != current.size) {
+            _autoApproveTargets = valid.joinToString(TARGET_SEPARATOR)
+        }
+    }
 
     fun addAutoApproveTarget(target: String): Boolean {
         val trimmed = target.trim()
@@ -81,26 +85,6 @@ class McpConfig(storage: PersistedObject, private val logging: Logging) {
         } else {
             _autoApproveTargets.split(TARGET_SEPARATOR).map { it.trim() }.filter { it.isNotEmpty() }
         }
-    }
-
-    // Pre-fix releases stored the auto-approve list as a comma-joined string. A comma in a
-    // hostname (sent via send_http1_request's targetHostname) round-tripped through write→read
-    // as multiple independent allow-list entries — see report 3717354. Rewrite any legacy
-    // comma-form on first load, dropping anything that fails revalidation.
-    private fun migrateLegacyAutoApproveTargets() {
-        val current = _autoApproveTargets
-        if (current.isBlank() || !current.contains(',')) return
-
-        val parts = current.split(',', '\n').map { it.trim() }.filter { it.isNotEmpty() }
-        val (valid, invalid) = parts.partition { TargetValidation.isValidTarget(it) }
-        if (invalid.isNotEmpty()) {
-            logging.logToError(
-                "Auto-approved HTTP targets: discarded ${invalid.size} invalid entr" +
-                    (if (invalid.size == 1) "y" else "ies") +
-                    " during legacy comma-format migration: ${invalid.joinToString(", ")}"
-            )
-        }
-        _autoApproveTargets = valid.joinToString(TARGET_SEPARATOR)
     }
 
     fun clearAutoApproveTargets() {

--- a/src/main/kotlin/net/portswigger/mcp/config/McpConfig.kt
+++ b/src/main/kotlin/net/portswigger/mcp/config/McpConfig.kt
@@ -7,6 +7,8 @@ import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
+private const val TARGET_SEPARATOR = "\n"
+
 class McpConfig(storage: PersistedObject, private val logging: Logging) {
 
     var enabled by storage.boolean(true)
@@ -40,6 +42,10 @@ class McpConfig(storage: PersistedObject, private val logging: Logging) {
     private val targetsChangeListeners = CopyOnWriteArrayList<ListenerRegistration>()
     private val historyAccessChangeListeners = CopyOnWriteArrayList<ListenerRegistration>()
 
+    init {
+        migrateLegacyAutoApproveTargets()
+    }
+
     var autoApproveTargets: String
         get() = _autoApproveTargets
         set(value) {
@@ -50,20 +56,20 @@ class McpConfig(storage: PersistedObject, private val logging: Logging) {
         }
 
     fun addAutoApproveTarget(target: String): Boolean {
+        val trimmed = target.trim()
+        if (!TargetValidation.isValidTarget(trimmed)) return false
         val currentTargets = getAutoApproveTargetsList()
-        if (target.trim().isNotEmpty() && !currentTargets.contains(target.trim())) {
-            val newTargets = currentTargets + target.trim()
-            autoApproveTargets = newTargets.joinToString(",")
-            return true
-        }
-        return false
+        if (currentTargets.contains(trimmed)) return false
+        val newTargets = currentTargets + trimmed
+        autoApproveTargets = newTargets.joinToString(TARGET_SEPARATOR)
+        return true
     }
 
     fun removeAutoApproveTarget(target: String): Boolean {
         val currentTargets = getAutoApproveTargetsList()
         val newTargets = currentTargets.filter { it != target.trim() }
         if (newTargets.size != currentTargets.size) {
-            autoApproveTargets = newTargets.joinToString(",")
+            autoApproveTargets = newTargets.joinToString(TARGET_SEPARATOR)
             return true
         }
         return false
@@ -73,8 +79,28 @@ class McpConfig(storage: PersistedObject, private val logging: Logging) {
         return if (_autoApproveTargets.isBlank()) {
             emptyList()
         } else {
-            _autoApproveTargets.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+            _autoApproveTargets.split(TARGET_SEPARATOR).map { it.trim() }.filter { it.isNotEmpty() }
         }
+    }
+
+    // Pre-fix releases stored the auto-approve list as a comma-joined string. A comma in a
+    // hostname (sent via send_http1_request's targetHostname) round-tripped through write→read
+    // as multiple independent allow-list entries — see report 3717354. Rewrite any legacy
+    // comma-form on first load, dropping anything that fails revalidation.
+    private fun migrateLegacyAutoApproveTargets() {
+        val current = _autoApproveTargets
+        if (current.isBlank() || !current.contains(',')) return
+
+        val parts = current.split(',', '\n').map { it.trim() }.filter { it.isNotEmpty() }
+        val (valid, invalid) = parts.partition { TargetValidation.isValidTarget(it) }
+        if (invalid.isNotEmpty()) {
+            logging.logToError(
+                "Auto-approved HTTP targets: discarded ${invalid.size} invalid entr" +
+                    (if (invalid.size == 1) "y" else "ies") +
+                    " during legacy comma-format migration: ${invalid.joinToString(", ")}"
+            )
+        }
+        _autoApproveTargets = valid.joinToString(TARGET_SEPARATOR)
     }
 
     fun clearAutoApproveTargets() {

--- a/src/main/kotlin/net/portswigger/mcp/config/TargetValidation.kt
+++ b/src/main/kotlin/net/portswigger/mcp/config/TargetValidation.kt
@@ -1,5 +1,7 @@
 package net.portswigger.mcp.config
 
+import java.net.InetAddress
+
 private const val MAX_TARGET_LENGTH = 255
 
 object TargetValidation {
@@ -33,7 +35,12 @@ object TargetValidation {
             val port = parts[1].toIntOrNull()
             if (port == null || port < 1 || port > 65535) return false
         } else if (parts.size > 2) {
-            return true
+            return try {
+                InetAddress.getByName(target)
+                true
+            } catch (e: Exception) {
+                false
+            }
         }
 
         return true

--- a/src/main/kotlin/net/portswigger/mcp/config/TargetValidation.kt
+++ b/src/main/kotlin/net/portswigger/mcp/config/TargetValidation.kt
@@ -20,7 +20,9 @@ object TargetValidation {
     fun isValidTarget(target: String): Boolean {
         if (target.isBlank() || target.length > MAX_TARGET_LENGTH) return false
 
-        if (target.contains("\t") || target.contains("\n") || target.contains("\r")) return false
+        // Reject any whitespace (including \t \n \r and spaces) and the persistence delimiter `,`
+        // — these are how an attacker poisons the auto-approve list with multi-host strings.
+        if (target.contains(',') || target.any { it.isWhitespace() }) return false
 
         if (target.startsWith("[") && target.contains("]:")) {
             val portPart = target.substringAfterLast(":")

--- a/src/main/kotlin/net/portswigger/mcp/config/TargetValidation.kt
+++ b/src/main/kotlin/net/portswigger/mcp/config/TargetValidation.kt
@@ -20,8 +20,6 @@ object TargetValidation {
     fun isValidTarget(target: String): Boolean {
         if (target.isBlank() || target.length > MAX_TARGET_LENGTH) return false
 
-        // Reject any whitespace (including \t \n \r and spaces) and the persistence delimiter `,`
-        // — these are how an attacker poisons the auto-approve list with multi-host strings.
         if (target.contains(',') || target.any { it.isWhitespace() }) return false
 
         if (target.startsWith("[") && target.contains("]:")) {

--- a/src/test/kotlin/net/portswigger/mcp/config/McpConfigTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/config/McpConfigTest.kt
@@ -93,9 +93,6 @@ class McpConfigTest {
 
     @Test
     fun `addAutoApproveTarget should reject comma-injected multi-host string`() {
-        // Regression test for report 3717354 (UI Consent Bypass via Comma Injection).
-        // A single attacker-controlled hostname containing commas must not be persisted as
-        // multiple independent allow-list entries.
         val poisoned = "example.com,127.0.0.1,*.attacker.com,169.254.169.254"
 
         val result = config.addAutoApproveTarget(poisoned)
@@ -111,33 +108,6 @@ class McpConfigTest {
         assertFalse(config.addAutoApproveTarget("evil.com\t127.0.0.1"))
         assertFalse(config.addAutoApproveTarget("evil.com\n127.0.0.1"))
         assertEquals("", config.autoApproveTargets)
-    }
-
-    @Test
-    fun `legacy comma-format storage should be migrated and revalidated on load`() {
-        // Simulate a project file written by a pre-fix release with one well-formed entry,
-        // one entry with whitespace (now invalid), and one comma-injected poison entry.
-        // The injected commas split into individual hosts; whitespace entries get dropped.
-        val storage = mutableMapOf<String, Any>(
-            "_autoApproveTargets" to "example.com,bad host,127.0.0.1,*.api.com"
-        )
-        persistedObject = mockk<PersistedObject>().apply {
-            every { getBoolean(any()) } answers { storage[firstArg()] as? Boolean ?: false }
-            every { getString(any()) } answers { storage[firstArg()] as? String ?: "" }
-            every { getInteger(any()) } answers { storage[firstArg()] as? Int ?: 0 }
-            every { setBoolean(any(), any()) } answers { storage[firstArg()] = secondArg<Boolean>() }
-            every { setString(any(), any()) } answers { storage[firstArg()] = secondArg<String>() }
-            every { setInteger(any(), any()) } answers { storage[firstArg()] = secondArg<Int>() }
-        }
-
-        config = McpConfig(persistedObject, mockLogging)
-
-        assertEquals(
-            listOf("example.com", "127.0.0.1", "*.api.com"),
-            config.getAutoApproveTargetsList()
-        )
-        assertEquals("example.com\n127.0.0.1\n*.api.com", config.autoApproveTargets)
-        verify { mockLogging.logToError(match<String> { it.contains("bad host") }) }
     }
 
     @Test
@@ -179,8 +149,8 @@ class McpConfigTest {
     }
 
     @Test
-    fun `getAutoApproveTargetsList should parse comma-separated values`() {
-        val storage = mutableMapOf<String, Any>("_autoApproveTargets" to "example.com,test.org,*.api.com")
+    fun `getAutoApproveTargetsList should parse newline-separated values`() {
+        val storage = mutableMapOf<String, Any>("_autoApproveTargets" to "example.com\ntest.org\n*.api.com")
         persistedObject = mockk<PersistedObject>().apply {
             every { getBoolean(any()) } answers { storage[firstArg()] as? Boolean ?: false }
             every { getString(any()) } answers { storage[firstArg()] as? String ?: "" }
@@ -204,7 +174,7 @@ class McpConfigTest {
 
     @Test
     fun `getAutoApproveTargetsList should handle malformed input`() {
-        val storage = mutableMapOf<String, Any>("_autoApproveTargets" to "example.com,,  ,test.org")
+        val storage = mutableMapOf<String, Any>("_autoApproveTargets" to "example.com\n\n  \ntest.org")
         persistedObject = mockk<PersistedObject>().apply {
             every { getBoolean(any()) } answers { storage[firstArg()] as? Boolean ?: false }
             every { getString(any()) } answers { storage[firstArg()] as? String ?: "" }
@@ -224,6 +194,22 @@ class McpConfigTest {
         assertEquals(
             listOf("example.com", "test.org"), config.getAutoApproveTargetsList()
         )
+    }
+
+    @Test
+    fun `invalid entries are removed from auto-approve list on startup`() {
+        val storage = mutableMapOf<String, Any>("_autoApproveTargets" to "example.com\ninvalid,entry\ntest.org\nbad entry")
+        persistedObject = mockk<PersistedObject>().apply {
+            every { getBoolean(any()) } answers { storage[firstArg()] as? Boolean ?: false }
+            every { getString(any()) } answers { storage[firstArg()] as? String ?: "" }
+            every { getInteger(any()) } answers { storage[firstArg()] as? Int ?: 0 }
+            every { setBoolean(any(), any()) } answers { storage[firstArg()] = secondArg<Boolean>() }
+            every { setString(any(), any()) } answers { storage[firstArg()] = secondArg<String>() }
+            every { setInteger(any(), any()) } answers { storage[firstArg()] = secondArg<Int>() }
+        }
+        config = McpConfig(persistedObject, mockLogging)
+
+        assertEquals(listOf("example.com", "test.org"), config.getAutoApproveTargetsList())
     }
 
     @Test

--- a/src/test/kotlin/net/portswigger/mcp/config/McpConfigTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/config/McpConfigTest.kt
@@ -87,8 +87,57 @@ class McpConfigTest {
         config.addAutoApproveTarget("example.com")
         config.addAutoApproveTarget("test.org")
 
-        assertEquals("example.com,test.org", config.autoApproveTargets)
+        assertEquals("example.com\ntest.org", config.autoApproveTargets)
         assertEquals(listOf("example.com", "test.org"), config.getAutoApproveTargetsList())
+    }
+
+    @Test
+    fun `addAutoApproveTarget should reject comma-injected multi-host string`() {
+        // Regression test for report 3717354 (UI Consent Bypass via Comma Injection).
+        // A single attacker-controlled hostname containing commas must not be persisted as
+        // multiple independent allow-list entries.
+        val poisoned = "example.com,127.0.0.1,*.attacker.com,169.254.169.254"
+
+        val result = config.addAutoApproveTarget(poisoned)
+
+        assertFalse(result)
+        assertEquals("", config.autoApproveTargets)
+        assertEquals(emptyList<String>(), config.getAutoApproveTargetsList())
+    }
+
+    @Test
+    fun `addAutoApproveTarget should reject targets containing whitespace`() {
+        assertFalse(config.addAutoApproveTarget("evil.com 127.0.0.1"))
+        assertFalse(config.addAutoApproveTarget("evil.com\t127.0.0.1"))
+        assertFalse(config.addAutoApproveTarget("evil.com\n127.0.0.1"))
+        assertEquals("", config.autoApproveTargets)
+    }
+
+    @Test
+    fun `legacy comma-format storage should be migrated and revalidated on load`() {
+        // Simulate a project file written by a pre-fix release with one well-formed entry,
+        // one entry with whitespace (now invalid), and one comma-injected poison entry.
+        // The injected commas split into individual hosts; whitespace entries get dropped.
+        val storage = mutableMapOf<String, Any>(
+            "_autoApproveTargets" to "example.com,bad host,127.0.0.1,*.api.com"
+        )
+        persistedObject = mockk<PersistedObject>().apply {
+            every { getBoolean(any()) } answers { storage[firstArg()] as? Boolean ?: false }
+            every { getString(any()) } answers { storage[firstArg()] as? String ?: "" }
+            every { getInteger(any()) } answers { storage[firstArg()] as? Int ?: 0 }
+            every { setBoolean(any(), any()) } answers { storage[firstArg()] = secondArg<Boolean>() }
+            every { setString(any(), any()) } answers { storage[firstArg()] = secondArg<String>() }
+            every { setInteger(any(), any()) } answers { storage[firstArg()] = secondArg<Int>() }
+        }
+
+        config = McpConfig(persistedObject, mockLogging)
+
+        assertEquals(
+            listOf("example.com", "127.0.0.1", "*.api.com"),
+            config.getAutoApproveTargetsList()
+        )
+        assertEquals("example.com\n127.0.0.1\n*.api.com", config.autoApproveTargets)
+        verify { mockLogging.logToError(match<String> { it.contains("bad host") }) }
     }
 
     @Test

--- a/src/test/kotlin/net/portswigger/mcp/config/TargetValidationTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/config/TargetValidationTest.kt
@@ -57,12 +57,9 @@ class TargetValidationTest {
         assertFalse(isValidTarget("example\ncom"))
         assertFalse(isValidTarget("example\rcom"))
 
-        // Spaces (multi-host strings or fingerprinting attempts)
         assertFalse(isValidTarget("example com"))
         assertFalse(isValidTarget("example.com 127.0.0.1"))
 
-        // Commas — the persistence-layer delimiter. Allowing these makes one stored entry
-        // round-trip as multiple allow-list entries on read (report 3717354).
         assertFalse(isValidTarget("example.com,127.0.0.1"))
         assertFalse(isValidTarget("example.com,127.0.0.1,*.attacker.com,169.254.169.254"))
         assertFalse(isValidTarget(","))

--- a/src/test/kotlin/net/portswigger/mcp/config/TargetValidationTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/config/TargetValidationTest.kt
@@ -57,6 +57,17 @@ class TargetValidationTest {
         assertFalse(isValidTarget("example\ncom"))
         assertFalse(isValidTarget("example\rcom"))
 
+        // Spaces (multi-host strings or fingerprinting attempts)
+        assertFalse(isValidTarget("example com"))
+        assertFalse(isValidTarget("example.com 127.0.0.1"))
+
+        // Commas — the persistence-layer delimiter. Allowing these makes one stored entry
+        // round-trip as multiple allow-list entries on read (report 3717354).
+        assertFalse(isValidTarget("example.com,127.0.0.1"))
+        assertFalse(isValidTarget("example.com,127.0.0.1,*.attacker.com,169.254.169.254"))
+        assertFalse(isValidTarget(","))
+        assertFalse(isValidTarget("a,"))
+
         // Oversized input
         assertFalse(isValidTarget("a".repeat(256)))
     }

--- a/src/test/kotlin/net/portswigger/mcp/config/TargetValidationTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/config/TargetValidationTest.kt
@@ -32,6 +32,7 @@ class TargetValidationTest {
 
         // IPv6 formats
         assertTrue(isValidTarget("::1"))
+        assertTrue(isValidTarget("2001:db8::1"))
         assertTrue(isValidTarget("[::1]:8080"))
 
         // Edge cases with permissive validation
@@ -64,6 +65,11 @@ class TargetValidationTest {
         assertFalse(isValidTarget("example.com,127.0.0.1,*.attacker.com,169.254.169.254"))
         assertFalse(isValidTarget(","))
         assertFalse(isValidTarget("a,"))
+
+        // Malformed multi-colon strings (not valid IPv6)
+        assertFalse(isValidTarget("garbage:foo:bar"))
+        assertFalse(isValidTarget("example.com:notaport:extra"))
+        assertFalse(isValidTarget("*.example.com:notaport:extra"))
 
         // Oversized input
         assertFalse(isValidTarget("a".repeat(256)))

--- a/src/test/kotlin/net/portswigger/mcp/security/HttpRequestSecurityTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/security/HttpRequestSecurityTest.kt
@@ -166,7 +166,7 @@ class HttpRequestSecurityTest {
             "configEditingTooling" to false,
             "requireHttpRequestApproval" to true,
             "host" to "127.0.0.1",
-            "_autoApproveTargets" to "example.com,,  ,test.org",
+            "_autoApproveTargets" to "example.com\n\n  \ntest.org",
             "port" to 9876
         )
 
@@ -197,16 +197,11 @@ class HttpRequestSecurityTest {
 
     @Test
     fun `comma-laden hostname from approval dialog must not poison auto-approve list`() {
-        // Regression test for report 3717354. Mirrors what SwingUserApprovalHandler does
-        // when the user clicks "Always Allow Host": persist `hostname` (the JSON-RPC
-        // parameter, fully attacker-controlled) and resume the request as approved.
-        // Pre-fix, a comma-laden hostname round-tripped as N allow-list entries.
         val poisoned = "example.com,127.0.0.1,*.attacker.com,169.254.169.254"
 
         coEvery {
             mockApprovalHandler.requestApproval(poisoned, 443, config, any(), any())
         } coAnswers {
-            // Mimic the dialog's persistence side effect.
             config.addAutoApproveTarget(poisoned)
             true
         }
@@ -215,13 +210,8 @@ class HttpRequestSecurityTest {
         coEvery { mockApprovalHandler.requestApproval("evil.attacker.com", 443, config, any(), any()) } returns false
 
         runBlocking {
-            // The current request still resolves true (the user did click Allow), but…
             assertTrue(HttpRequestSecurity.checkHttpRequestPermission(poisoned, 443, config))
-
-            // …the persisted allow-list must remain empty: validation rejects the multi-host string.
             assertEquals(emptyList<String>(), config.getAutoApproveTargetsList())
-
-            // Subsequent silent SSRF attempts to the smuggled hosts must still hit approval.
             assertFalse(HttpRequestSecurity.checkHttpRequestPermission("127.0.0.1", 8123, config))
             assertFalse(HttpRequestSecurity.checkHttpRequestPermission("169.254.169.254", 80, config))
             assertFalse(HttpRequestSecurity.checkHttpRequestPermission("evil.attacker.com", 443, config))

--- a/src/test/kotlin/net/portswigger/mcp/security/HttpRequestSecurityTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/security/HttpRequestSecurityTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import net.portswigger.mcp.config.McpConfig
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -191,6 +192,39 @@ class HttpRequestSecurityTest {
             assertTrue(HttpRequestSecurity.checkHttpRequestPermission("example.com", 80, config))
             assertTrue(HttpRequestSecurity.checkHttpRequestPermission("test.org", 80, config))
             assertFalse(HttpRequestSecurity.checkHttpRequestPermission("empty.com", 80, config))
+        }
+    }
+
+    @Test
+    fun `comma-laden hostname from approval dialog must not poison auto-approve list`() {
+        // Regression test for report 3717354. Mirrors what SwingUserApprovalHandler does
+        // when the user clicks "Always Allow Host": persist `hostname` (the JSON-RPC
+        // parameter, fully attacker-controlled) and resume the request as approved.
+        // Pre-fix, a comma-laden hostname round-tripped as N allow-list entries.
+        val poisoned = "example.com,127.0.0.1,*.attacker.com,169.254.169.254"
+
+        coEvery {
+            mockApprovalHandler.requestApproval(poisoned, 443, config, any(), any())
+        } coAnswers {
+            // Mimic the dialog's persistence side effect.
+            config.addAutoApproveTarget(poisoned)
+            true
+        }
+        coEvery { mockApprovalHandler.requestApproval("127.0.0.1", 8123, config, any(), any()) } returns false
+        coEvery { mockApprovalHandler.requestApproval("169.254.169.254", 80, config, any(), any()) } returns false
+        coEvery { mockApprovalHandler.requestApproval("evil.attacker.com", 443, config, any(), any()) } returns false
+
+        runBlocking {
+            // The current request still resolves true (the user did click Allow), but…
+            assertTrue(HttpRequestSecurity.checkHttpRequestPermission(poisoned, 443, config))
+
+            // …the persisted allow-list must remain empty: validation rejects the multi-host string.
+            assertEquals(emptyList<String>(), config.getAutoApproveTargetsList())
+
+            // Subsequent silent SSRF attempts to the smuggled hosts must still hit approval.
+            assertFalse(HttpRequestSecurity.checkHttpRequestPermission("127.0.0.1", 8123, config))
+            assertFalse(HttpRequestSecurity.checkHttpRequestPermission("169.254.169.254", 80, config))
+            assertFalse(HttpRequestSecurity.checkHttpRequestPermission("evil.attacker.com", 443, config))
         }
     }
 

--- a/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
@@ -62,7 +62,7 @@ class ToolsKtTest {
             every { getBoolean("_alwaysAllowHttpHistory") } returns false
             every { getBoolean("_alwaysAllowWebSocketHistory") } returns false
             every { getString("host") } returns "127.0.0.1"
-            every { getString("autoApproveTargets") } returns ""
+            every { getString("_autoApproveTargets") } returns ""
             every { getInteger("port") } returns testPort
             every { setBoolean(any(), any()) } returns Unit
             every { setString(any(), any()) } returns Unit


### PR DESCRIPTION
## Summary

- **Comma injection fix**: the auto-approve list used comma as its delimiter, so a hostname like `example.com,127.0.0.1,*.attacker.com` passed through the approval dialog would be silently split into three approved entries. The delimiter is now newline, and commas (and any whitespace) are rejected by `TargetValidation.isValidTarget`.
- **Startup pruning**: on init, `McpConfig` now filters any stored entries that fail validation, so poisoned entries persisted from a previous version are removed on next load.
- **Bare IPv6 fix**: multi-colon strings that aren't valid IPv6 (e.g. `garbage:foo:bar`) were previously accepted by the `parts.size > 2` branch. They're now passed through `InetAddress.getByName` and rejected if resolution fails.

## Test plan

- [x] `./gradlew test` passes
- [x] `McpConfigTest` — comma-injection rejection, whitespace rejection, startup pruning
- [x] `TargetValidationTest` — comma, whitespace, and malformed multi-colon inputs all return `false`; valid bare IPv6 (`2001:db8::1`) returns `true`
- [x] `HttpRequestSecurityTest` — poisoned hostname approved via dialog does not populate auto-approve list