### PR TITLE
Surface MCP HTTP requests in Site Map and normalize Repeater newlines

### DIFF
--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -60,6 +60,8 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
         val request = HttpRequest.httpRequest(toMontoyaService(), fixedContent)
         val response = api.http().sendRequest(request)
 
+        response?.takeIf { it.hasResponse() }?.let { api.siteMap().add(it) }
+
         response?.toString() ?: "<no response>"
     }
 
@@ -111,11 +113,14 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
         val request = HttpRequest.http2Request(toMontoyaService(), headerList, requestBody)
         val response = api.http().sendRequest(request, HttpMode.HTTP_2)
 
+        response?.takeIf { it.hasResponse() }?.let { api.siteMap().add(it) }
+
         response?.toString() ?: "<no response>"
     }
 
     mcpTool<CreateRepeaterTab>("Creates a new Repeater tab with the specified HTTP request and optional tab name. Make sure to use carriage returns appropriately.") {
-        val request = HttpRequest.httpRequest(toMontoyaService(), content)
+        val fixedContent = content.replace("\r", "").replace("\n", "\r\n")
+        val request = HttpRequest.httpRequest(toMontoyaService(), fixedContent)
         api.repeater().sendToRepeater(request, tabName)
     }
 

--- a/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
@@ -173,6 +173,7 @@ class ToolsKtTest {
             }
             every { api.http() } returns httpService
             every { httpResponse.toString() } returns "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nResponse body"
+            every { httpResponse.hasResponse() } returns true
             every { httpService.sendRequest(capture(capturedRequest)) } returns httpResponse
 
             runBlocking {
@@ -192,6 +193,7 @@ class ToolsKtTest {
             }
 
             verify(exactly = 1) { httpService.sendRequest(any<HttpRequest>()) }
+            verify(exactly = 1) { api.siteMap().add(httpResponse) }
             assertEquals("GET /foo HTTP/1.1\r\nHost: example.com\r\n\r\n", capturedRequest.captured.toString(), "Request body should match")
         }
 
@@ -222,6 +224,8 @@ class ToolsKtTest {
                 delay(100)
                 result.expectTextContent("<no response>")
             }
+
+            verify(exactly = 0) { api.siteMap().add(any<burp.api.montoya.http.message.HttpRequestResponse>()) }
         }
 
         @Test
@@ -235,6 +239,7 @@ class ToolsKtTest {
 
             every { HttpRequest.http2Request(any(), capture(headersSlot), capture(bodySlot)) } returns httpRequest
             every { httpResponse.toString() } returns "HTTP/2 200 OK\r\nContent-Type: text/plain\r\n\r\nResponse body"
+            every { httpResponse.hasResponse() } returns true
             every { api.http() } returns httpService
             every { httpService.sendRequest(capture(requestSlot), HttpMode.HTTP_2) } returns httpResponse
 
@@ -265,7 +270,8 @@ class ToolsKtTest {
             }
 
             verify(exactly = 1) { HttpRequest.http2Request(any(), any(), any<String>()) }
-            
+            verify(exactly = 1) { api.siteMap().add(httpResponse) }
+
             assertEquals("Test body", bodySlot.captured, "Request body should match")
             
             val pseudoHeaderList = headersSlot.captured.filter { it.name().startsWith(":") }
@@ -307,8 +313,76 @@ class ToolsKtTest {
                 delay(100)
                 result.expectTextContent("<no response>")
             }
+
+            verify(exactly = 0) { api.siteMap().add(any<burp.api.montoya.http.message.HttpRequestResponse>()) }
         }
-        
+
+        @Test
+        fun `http2 should not add to site map when response is missing`() {
+            val httpService = mockk<Http>()
+            val httpRequest = mockk<HttpRequest>()
+            val httpResponse = mockk<burp.api.montoya.http.message.HttpRequestResponse>()
+
+            every { HttpRequest.http2Request(any(), any(), any<String>()) } returns httpRequest
+            every { api.http() } returns httpService
+            every { httpService.sendRequest(any(), HttpMode.HTTP_2) } returns httpResponse
+            every { httpResponse.hasResponse() } returns false
+            every { httpResponse.toString() } returns "HttpRequestResponse{httpRequest=..., httpResponse=null}"
+
+            val pseudoHeaders = mapOf("method" to "GET", "path" to "/test", "authority" to "example.com", "scheme" to "https")
+            val headers = mapOf("User-Agent" to "Test Agent")
+
+            runBlocking {
+                val result = client.callTool(
+                    "send_http2_request", mapOf(
+                        "pseudoHeaders" to Json.encodeToJsonElement(pseudoHeaders),
+                        "headers" to Json.encodeToJsonElement(headers),
+                        "requestBody" to "",
+                        "targetHostname" to "example.com",
+                        "targetPort" to 443,
+                        "usesHttps" to true
+                    )
+                )
+
+                delay(100)
+                assertNotNull(result)
+            }
+
+            verify(exactly = 0) { api.siteMap().add(any<burp.api.montoya.http.message.HttpRequestResponse>()) }
+        }
+
+        @Test
+        fun `create repeater tab should normalize line endings`() {
+            val repeater = mockk<burp.api.montoya.repeater.Repeater>(relaxed = true)
+            val contentSlot = slot<String>()
+
+            every { HttpRequest.httpRequest(any(), capture(contentSlot)) } answers {
+                val captured = secondArg<String>()
+                mockk<HttpRequest>().also {
+                    every { it.toString() } returns captured
+                }
+            }
+            every { api.repeater() } returns repeater
+
+            runBlocking {
+                val result = client.callTool(
+                    "create_repeater_tab", mapOf(
+                        "tabName" to "lf-only",
+                        "content" to "GET /foo HTTP/1.1\nHost: example.com\n\n",
+                        "targetHostname" to "example.com",
+                        "targetPort" to 80,
+                        "usesHttps" to false
+                    )
+                )
+
+                delay(100)
+                assertNotNull(result)
+            }
+
+            verify(exactly = 1) { repeater.sendToRepeater(any<HttpRequest>(), "lf-only") }
+            assertEquals("GET /foo HTTP/1.1\r\nHost: example.com\r\n\r\n", contentSlot.captured, "LF should be normalized to CRLF before sending to Repeater")
+        }
+
         @Test
         fun `http2 pseudo headers should be ordered correctly`() {
             val httpService = mockk<Http>()


### PR DESCRIPTION
## Summary

- **Site Map visibility for sent requests**: `send_http1_request` and `send_http2_request` route through `api.http().sendRequest()`, which bypasses Burp's proxy. Without intervention, MCP-issued requests are invisible to the user — Proxy History is read-only to extensions, and the existing `logToOutput` line only records `host:port`. Each tool now calls `api.siteMap().add(response)` after a successful send so the request/response pair shows up under Target > Site map.
- **Newline normalization in `create_repeater_tab`**: callers (LLMs in particular) often pass content with bare LF line terminators. The existing code forwarded that straight to `HttpRequest.httpRequest`, producing a garbled request in the Repeater tab that had to be hand-corrected. `create_repeater_tab` now applies the same `\n` → `\r\n` normalization that `send_http1_request` already uses (`Tools.kt:58`).
- No new tools, no API surface changes, no removed parameters.

## Test plan

- [x] `./gradlew test` passes (16 tests in `ToolsKtTest`)
- [x] `verify { api.siteMap().add(httpResponse) }` on the success path of both `send_http1_request` and `send_http2_request`
- [x] `verify(exactly = 0) { api.siteMap().add(any()) }` when `sendRequest` returns null (no spurious site-map entries on connection failure)
- [x] New `create repeater tab should normalize line endings` test asserts LF-only input is rewritten to CRLF before reaching Repeater

## Manual verification

- Issued an HTTP/1.1 and HTTP/2 request via the MCP against an in-scope host; both appeared under Target > Site map with full request/response, where previously nothing was visible.
- Created a Repeater tab with content containing only `\n` line breaks; the resulting tab renders cleanly without manually re-entering carriage returns.