### PR TITLE
Normalize only the HTTP request prelude, not the body

### DIFF
--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -43,18 +43,47 @@ private fun truncateIfNeeded(serialized: String): String {
 }
 
 /**
- * Normalizes HTTP content line endings from MCP clients.
+ * Normalizes HTTP request line endings from MCP clients.
  *
- * MCP clients (e.g. Claude Code) pass \r\n as literal escape sequences in JSON
- * tool parameters, which arrive as the 4-character text sequences backslash-r
- * and backslash-n rather than actual CR (0x0D) and LF (0x0A) bytes.
- * This produces malformed HTTP that strict servers (e.g. Apache-Coyote) reject
- * with 400 Bad Request.
+ * MCP clients (e.g. Claude Code) often emit `\r\n` as the 4-character literal
+ * sequence backslash-r-backslash-n in JSON tool parameters rather than actual
+ * CR (0x0D) + LF (0x0A) bytes. The resulting text parses as a single line,
+ * which strict servers (e.g. Apache-Coyote) reject with 400 Bad Request and
+ * which Burp/Montoya may "repair" by injecting headers after the body
+ * separator.
  *
- * This function converts both literal escape sequences and actual line endings
- * into proper HTTP CRLF line termination.
+ * Normalization is applied only to the request prelude (request line and
+ * headers, up to and including the first blank line). The body is preserved
+ * verbatim so that legitimate escape sequences in bodies — e.g. `\n` inside a
+ * JSON string literal — and binary payloads remain byte-exact. If no blank
+ * line is present, the entire content is treated as prelude.
  */
-private fun normalizeHttpContent(content: String): String = content
+internal fun normalizeHttpContent(content: String): String {
+    val preludeEnd = findPreludeEnd(content) ?: return normalizePrelude(content)
+    return normalizePrelude(content.substring(0, preludeEnd)) + content.substring(preludeEnd)
+}
+
+private val BLANK_LINE_MARKERS = listOf(
+    "\r\n\r\n",         // actual CRLF blank line
+    "\n\n",              // actual LF blank line
+    "\\r\\n\\r\\n",     // literal CRLF blank line
+    "\\n\\n",            // literal LF blank line
+)
+
+private fun findPreludeEnd(content: String): Int? {
+    var bestStart = -1
+    var bestLen = 0
+    for (marker in BLANK_LINE_MARKERS) {
+        val idx = content.indexOf(marker)
+        if (idx >= 0 && (bestStart < 0 || idx < bestStart)) {
+            bestStart = idx
+            bestLen = marker.length
+        }
+    }
+    return if (bestStart < 0) null else bestStart + bestLen
+}
+
+private fun normalizePrelude(prelude: String): String = prelude
     .replace("\\r\\n", "\n")   // Literal \r\n escape sequences → LF
     .replace("\\n", "\n")      // Remaining literal \n → LF
     .replace("\\r", "")        // Remaining literal \r → remove

--- a/src/test/kotlin/net/portswigger/mcp/tools/NormalizeHttpContentTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/NormalizeHttpContentTest.kt
@@ -1,0 +1,125 @@
+package net.portswigger.mcp.tools
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class NormalizeHttpContentTest {
+
+    @Nested
+    inner class PreludeNormalization {
+
+        @Test
+        fun `literal backslash-r backslash-n sequences become CRLF`() {
+            val input = "GET /foo HTTP/1.1\\r\\nHost: example.com\\r\\n\\r\\n"
+            val expected = "GET /foo HTTP/1.1\r\nHost: example.com\r\n\r\n"
+
+            assertEquals(expected, normalizeHttpContent(input))
+        }
+
+        @Test
+        fun `bare LFs become CRLF`() {
+            val input = "GET /foo HTTP/1.1\nHost: example.com\n\n"
+            val expected = "GET /foo HTTP/1.1\r\nHost: example.com\r\n\r\n"
+
+            assertEquals(expected, normalizeHttpContent(input))
+        }
+
+        @Test
+        fun `already-correct CRLFs are preserved`() {
+            val input = "GET /foo HTTP/1.1\r\nHost: example.com\r\n\r\n"
+
+            assertEquals(input, normalizeHttpContent(input))
+        }
+
+        @Test
+        fun `literal backslash-n only is treated as a line break`() {
+            val input = "GET /foo HTTP/1.1\\nHost: example.com\\n\\n"
+            val expected = "GET /foo HTTP/1.1\r\nHost: example.com\r\n\r\n"
+
+            assertEquals(expected, normalizeHttpContent(input))
+        }
+
+        @Test
+        fun `stray literal backslash-r characters are stripped`() {
+            val input = "GET /foo HTTP/1.1\\r\\nHost: example.com\\r\\r\\n\\r\\n"
+            val expected = "GET /foo HTTP/1.1\r\nHost: example.com\r\n\r\n"
+
+            assertEquals(expected, normalizeHttpContent(input))
+        }
+    }
+
+    @Nested
+    inner class BodyPreservation {
+
+        @Test
+        fun `JSON body containing literal backslash-n is left untouched`() {
+            val input =
+                "POST /api HTTP/1.1\\r\\nHost: example.com\\r\\nContent-Type: application/json\\r\\nContent-Length: 25\\r\\n\\r\\n" +
+                        "{\"text\": \"hello\\nworld\"}"
+            val expected =
+                "POST /api HTTP/1.1\r\nHost: example.com\r\nContent-Type: application/json\r\nContent-Length: 25\r\n\r\n" +
+                        "{\"text\": \"hello\\nworld\"}"
+
+            assertEquals(expected, normalizeHttpContent(input))
+        }
+
+        @Test
+        fun `body containing real LFs is left untouched`() {
+            val input =
+                "POST /api HTTP/1.1\r\nHost: example.com\r\nContent-Length: 11\r\n\r\n" +
+                        "line1\nline2"
+            val expected =
+                "POST /api HTTP/1.1\r\nHost: example.com\r\nContent-Length: 11\r\n\r\n" +
+                        "line1\nline2"
+
+            assertEquals(expected, normalizeHttpContent(input))
+        }
+
+        @Test
+        fun `body containing literal backslash-r-backslash-n is left untouched`() {
+            val input =
+                "POST /api HTTP/1.1\\r\\nHost: example.com\\r\\nContent-Length: 18\\r\\n\\r\\n" +
+                        "raw=value\\r\\nother"
+            val expected =
+                "POST /api HTTP/1.1\r\nHost: example.com\r\nContent-Length: 18\r\n\r\n" +
+                        "raw=value\\r\\nother"
+
+            assertEquals(expected, normalizeHttpContent(input))
+        }
+
+        @Test
+        fun `empty body after blank line is preserved`() {
+            val input = "GET / HTTP/1.1\\r\\nHost: example.com\\r\\n\\r\\n"
+            val expected = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
+
+            assertEquals(expected, normalizeHttpContent(input))
+        }
+    }
+
+    @Nested
+    inner class SeparatorDetection {
+
+        @Test
+        fun `earliest separator wins when both literal and actual are present`() {
+            // Prelude uses actual CRLF; body happens to contain a literal "\r\n\r\n" sequence.
+            // The actual blank line must be detected first, leaving the body verbatim.
+            val input =
+                "POST /api HTTP/1.1\r\nHost: example.com\r\n\r\n" +
+                        "payload=foo\\r\\n\\r\\nbar"
+            val expected =
+                "POST /api HTTP/1.1\r\nHost: example.com\r\n\r\n" +
+                        "payload=foo\\r\\n\\r\\nbar"
+
+            assertEquals(expected, normalizeHttpContent(input))
+        }
+
+        @Test
+        fun `no blank line means whole content is treated as prelude`() {
+            val input = "GET /foo HTTP/1.1\\r\\nHost: example.com\\r\\n"
+            val expected = "GET /foo HTTP/1.1\r\nHost: example.com\r\n"
+
+            assertEquals(expected, normalizeHttpContent(input))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #58. The line-ending normalization there operated on the entire request content, which corrupts bodies containing legitimate escape-sequence text or real LFs.

For example, a JSON body like `{"text":"hello\nworld"}` (where `\n` is two literal characters, not a newline) was being rewritten so the `\n` became a real CRLF inside the body — breaking both the JSON structure and the `Content-Length` byte count. Bodies containing actual LFs were similarly converted to CRLF.

This PR restricts normalization to the request prelude (request line + headers, up to and including the first blank line). The body is preserved verbatim.

## Approach

`normalizeHttpContent` now:

1. Searches for the first blank-line separator in any of four forms — actual `\r\n\r\n`, actual `\n\n`, literal `\r\n\r\n` (8 backslash-escaped chars), literal `\n\n` (4 backslash-escaped chars) — and picks the **earliest** match. Since header values can't contain newlines in valid HTTP, the earliest match is always the real separator regardless of what the body contains.
2. Applies the existing five-step `replace` chain only to the prelude (everything up to and including the chosen separator).
3. Concatenates the unmodified body.

If no blank line is found, the whole content is treated as prelude (preserving the previous behaviour for malformed inputs).

## Tests

Adds `NormalizeHttpContentTest` with 11 cases covering:

- **Prelude normalization**: literal `\r\n`, bare LF, literal `\n`-only, stray literal `\r`, and already-correct CRLF inputs.
- **Body preservation**: JSON bodies with literal `\n`, bodies with real LFs, bodies containing literal `\r\n\r\n`, and empty bodies.
- **Separator detection**: earliest-match selection when both forms appear in the same content, and the no-blank-line fallback.

`normalizeHttpContent` is now `internal` to allow direct unit testing instead of routing every assertion through the SSE MCP integration harness.

## Test plan

- [x] `./gradlew test --tests "net.portswigger.mcp.tools.NormalizeHttpContentTest"` — all 11 new tests pass
- [x] `./gradlew test` — full suite passes, no regressions (including the existing `http1 line endings should be normalized` integration test)