### PR TITLE
Detect Windows Store Claude Desktop config path

### DIFF
--- a/src/main/kotlin/net/portswigger/mcp/providers/Provider.kt
+++ b/src/main/kotlin/net/portswigger/mcp/providers/Provider.kt
@@ -68,14 +68,16 @@ class ClaudeDesktopProvider(private val logging: Logging, private val proxyJarMa
         val os = System.getProperty("os.name").lowercase()
         val home = System.getProperty("user.home")
 
-        val basePath = when {
-            os.contains("win") -> Path.of(home, "AppData", "Roaming", "Claude")
-            os.contains("mac") || os.contains("darwin") -> Path.of(home, "Library", "Application Support", "Claude")
-            os.contains("linux") -> Path.of(home, ".config", "Claude")
+        val candidatePaths = when {
+            os.contains("win") -> windowsCandidatePaths(home)
+            os.contains("mac") || os.contains("darwin") -> listOf(
+                Path.of(home, "Library", "Application Support", "Claude")
+            )
+            os.contains("linux") -> listOf(Path.of(home, ".config", "Claude"))
             else -> return null
         }
 
-        if (!basePath.exists()) return null
+        val basePath = candidatePaths.firstOrNull { it.exists() } ?: return null
 
         val configFile = basePath.resolve(claudeConfigFileName)
         if (!configFile.exists()) {
@@ -83,6 +85,24 @@ class ClaudeDesktopProvider(private val logging: Logging, private val proxyJarMa
         }
 
         return configFile
+    }
+
+    internal fun windowsCandidatePaths(home: String): List<Path> {
+        val traditional = Path.of(home, "AppData", "Roaming", "Claude")
+
+        // Windows Store installs place config under a package directory with a random suffix:
+        // AppData\Local\Packages\Claude_<suffix>\LocalCache\Roaming\Claude
+        val packagesDir = Path.of(home, "AppData", "Local", "Packages")
+        val storePaths = if (packagesDir.exists()) {
+            packagesDir.toFile()
+                .listFiles { f -> f.isDirectory && f.name.startsWith("Claude_") }
+                ?.map { Path.of(it.absolutePath, "LocalCache", "Roaming", "Claude") }
+                ?: emptyList()
+        } else {
+            emptyList()
+        }
+
+        return listOf(traditional) + storePaths
     }
 
     private fun createDefaultConfig(path: Path): Boolean {

--- a/src/main/kotlin/net/portswigger/mcp/providers/Provider.kt
+++ b/src/main/kotlin/net/portswigger/mcp/providers/Provider.kt
@@ -9,6 +9,9 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import javax.swing.JFileChooser
 import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.name
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
 
@@ -77,7 +80,11 @@ class ClaudeDesktopProvider(private val logging: Logging, private val proxyJarMa
             else -> return null
         }
 
-        val basePath = candidatePaths.firstOrNull { it.exists() } ?: return null
+        val existingPaths = candidatePaths.filter { it.exists() }
+        if (existingPaths.size > 1) {
+            logging.logToOutput("Warning: multiple Claude Desktop config directories found; using ${existingPaths.first()}: $existingPaths")
+        }
+        val basePath = existingPaths.firstOrNull() ?: return null
 
         val configFile = basePath.resolve(claudeConfigFileName)
         if (!configFile.exists()) {
@@ -94,10 +101,9 @@ class ClaudeDesktopProvider(private val logging: Logging, private val proxyJarMa
         // AppData\Local\Packages\Claude_<suffix>\LocalCache\Roaming\Claude
         val packagesDir = Path.of(home, "AppData", "Local", "Packages")
         val storePaths = if (packagesDir.exists()) {
-            packagesDir.toFile()
-                .listFiles { f -> f.isDirectory && f.name.startsWith("Claude_") }
-                ?.map { Path.of(it.absolutePath, "LocalCache", "Roaming", "Claude") }
-                ?: emptyList()
+            packagesDir.listDirectoryEntries()
+                .filter { it.isDirectory() && it.name.startsWith("Claude_") }
+                .map { it.resolve("LocalCache").resolve("Roaming").resolve("Claude") }
         } else {
             emptyList()
         }

--- a/src/test/kotlin/net/portswigger/mcp/providers/ClaudeDesktopProviderTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/providers/ClaudeDesktopProviderTest.kt
@@ -1,0 +1,60 @@
+package net.portswigger.mcp.providers
+
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+
+class ClaudeDesktopProviderTest {
+
+    private val provider = ClaudeDesktopProvider(mockk(relaxed = true), mockk(relaxed = true))
+
+    @Test
+    fun `windowsCandidatePaths includes traditional path first`(@TempDir home: Path) {
+        val paths = provider.windowsCandidatePaths(home.toString())
+
+        assertEquals(home.resolve("AppData").resolve("Roaming").resolve("Claude"), paths.first())
+    }
+
+    @Test
+    fun `windowsCandidatePaths includes Store path when Claude_ package directory exists`(@TempDir home: Path) {
+        val storeDir = home.resolve("AppData/Local/Packages/Claude_abc123/LocalCache/Roaming/Claude")
+        storeDir.createDirectories()
+
+        val paths = provider.windowsCandidatePaths(home.toString())
+
+        assertTrue(paths.contains(storeDir), "Expected Store path in candidates: $paths")
+    }
+
+    @Test
+    fun `windowsCandidatePaths does not include Store path when no Claude_ packages exist`(@TempDir home: Path) {
+        home.resolve("AppData/Local/Packages/OtherApp_xyz").createDirectories()
+
+        val paths = provider.windowsCandidatePaths(home.toString())
+
+        assertEquals(1, paths.size)
+        assertEquals(home.resolve("AppData/Roaming/Claude"), paths.first())
+    }
+
+    @Test
+    fun `windowsCandidatePaths returns only traditional path when Packages dir does not exist`(@TempDir home: Path) {
+        val paths = provider.windowsCandidatePaths(home.toString())
+
+        assertEquals(listOf(home.resolve("AppData/Roaming/Claude")), paths)
+    }
+
+    @Test
+    fun `windowsCandidatePaths includes multiple Store packages if present`(@TempDir home: Path) {
+        home.resolve("AppData/Local/Packages/Claude_aaa/LocalCache/Roaming/Claude").createDirectories()
+        home.resolve("AppData/Local/Packages/Claude_bbb/LocalCache/Roaming/Claude").createDirectories()
+
+        val paths = provider.windowsCandidatePaths(home.toString())
+
+        assertEquals(3, paths.size)
+        assertTrue(paths.any { it.endsWith(Path.of("Claude_aaa/LocalCache/Roaming/Claude")) })
+        assertTrue(paths.any { it.endsWith(Path.of("Claude_bbb/LocalCache/Roaming/Claude")) })
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes #68, #65
- The existing installer hardcodes `AppData\Roaming\Claude` on Windows, which is where the traditional Claude Desktop installer puts its config. The Windows Store version installs to `AppData\Local\Packages\Claude_<suffix>\LocalCache\Roaming\Claude` instead, causing the "Could not find Claude config path" error.
- `configFilePath()` now tries the traditional path first, then scans `AppData\Local\Packages\` for any directory starting with `Claude_` and checks for the config under `LocalCache\Roaming\Claude`.
- Existing behavior on non-Windows and traditional Windows installs is unchanged.

## Test plan

- [x] `./gradlew test` passes (97 tests)
- [x] New `ClaudeDesktopProviderTest` covers: traditional path returned first, Store path included when `Claude_*` package dir exists, Store path excluded when no matching packages, no Packages dir present, multiple Store packages present