### PR TITLE
Upgrade MCP Kotlin SDK from 0.7.4 to 0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,9 @@ If you want to install the MCP server manually you can either use the extension'
 Stdio proxy server.
 
 ### SSE MCP Server
-In order to use the SSE server directly you can just provide the url for the server in your client's configuration. Depending
-on your client and your configuration in the extension this may be with or without the `/sse` path.
+To use the SSE server directly, provide the configured server URL to your MCP client:
 ```
 http://127.0.0.1:9876
-```
-or
-```
-http://127.0.0.1:9876/sse
 ```
 
 ### Stdio MCP Proxy Server
@@ -132,12 +127,22 @@ Once you have the jar you can add the following command and args to your client 
 /path/to/packaged/burp/java -jar /path/to/proxy/jar/mcp-proxy-all.jar --sse-url http://127.0.0.1:9876
 ```
 
+If you modify the proxy source, rebuild and copy it into this project before packaging the extension:
+```bash
+# From mcp-proxy
+./gradlew shadowJar
+cp build/libs/mcp-proxy-all.jar /path/to/mcp-server/libs/mcp-proxy-all.jar
+
+# From mcp-server
+./gradlew embedProxyJar
+```
+
 ### Creating / modifying tools
 
 Tools are defined in `src/main/kotlin/net/portswigger/mcp/tools/Tools.kt`. To define new tools, create a new serializable
 data class with the required parameters which will come from the LLM.
 
 The tool name is auto-derived from its parameters data class. A description is also needed for the LLM. You can return
-a string (or richer PromptMessageContents) to provide data back to the LLM.
+a string or a `List<ContentBlock>` to provide data back to the LLM.
 
 Extend the Paginated interface to add auto-pagination support.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,8 +65,8 @@ kotlin {
     }
 
     compilerOptions {
-        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
-        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_4)
+        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_4)
         jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
         freeCompilerArgs.addAll(
             "-Xjsr305=strict"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ ktor = "3.3.1"
 
 # Runtime Dependencies
 kotlinx-serialization = "1.9.0"
-mcp-sdk = "0.7.4"
+mcp-sdk = "0.12.0"
 burp-montoya = "2025.10"
 
 # Test Dependencies

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 # Build System
-kotlin = "2.2.21"
+kotlin = "2.4.0"
 ktor = "3.3.1"
 
 # Runtime Dependencies
 kotlinx-serialization = "1.9.0"
-mcp-sdk = "0.12.0"
+mcp-sdk = "0.15.0"
 burp-montoya = "2025.10"
 
 # Test Dependencies

--- a/src/main/kotlin/net/portswigger/mcp/KtorServerManager.kt
+++ b/src/main/kotlin/net/portswigger/mcp/KtorServerManager.kt
@@ -8,9 +8,9 @@ import io.ktor.server.netty.*
 import io.ktor.server.plugins.cors.routing.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
-import io.modelcontextprotocol.kotlin.sdk.Implementation
-import io.modelcontextprotocol.kotlin.sdk.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.mcp
 import net.portswigger.mcp.config.McpConfig

--- a/src/main/kotlin/net/portswigger/mcp/schema/JsonSchema.kt
+++ b/src/main/kotlin/net/portswigger/mcp/schema/JsonSchema.kt
@@ -1,6 +1,6 @@
 package net.portswigger.mcp.schema
 
-import io.modelcontextprotocol.kotlin.sdk.Tool
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -44,7 +44,7 @@ fun getJsonSchemaForProperty(kType: kotlin.reflect.KType): JsonElement {
     }
 }
 
-fun KClass<*>.asInputSchema(): Tool.Input {
+fun KClass<*>.asInputSchema(): ToolSchema {
     val properties = mutableMapOf<String, JsonElement>()
     val required = mutableListOf<String>()
 
@@ -56,7 +56,7 @@ fun KClass<*>.asInputSchema(): Tool.Input {
         }
     }
 
-    return Tool.Input(
+    return ToolSchema(
         properties = JsonObject(properties),
         required = required
     )

--- a/src/main/kotlin/net/portswigger/mcp/tools/McpTool.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/McpTool.kt
@@ -31,7 +31,8 @@ inline fun <reified I : Any> Server.mcpTool(
                         serializer,
                         request.params.arguments ?: JsonObject(emptyMap())
                     )
-                )
+                ),
+                isError = false
             )
         } catch (e: Exception) {
             CallToolResult(
@@ -119,7 +120,7 @@ inline fun Server.mcpTool(
     crossinline execute: () -> List<ContentBlock>
 ) {
     val handler: suspend (ClientConnection, CallToolRequest) -> CallToolResult = { _, _ ->
-        CallToolResult(content = execute())
+        CallToolResult(content = execute(), isError = false)
     }
     addTool(name = name, description = description, inputSchema = ToolSchema(), handler = handler)
 }
@@ -130,7 +131,7 @@ inline fun Server.mcpTool(
     crossinline execute: () -> String
 ) {
     val handler: suspend (ClientConnection, CallToolRequest) -> CallToolResult = { _, _ ->
-        CallToolResult(content = listOf(TextContent(execute())))
+        CallToolResult(content = listOf(TextContent(execute())), isError = false)
     }
     addTool(name = name, description = description, inputSchema = ToolSchema(), handler = handler)
 }

--- a/src/main/kotlin/net/portswigger/mcp/tools/McpTool.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/McpTool.kt
@@ -1,12 +1,15 @@
 package net.portswigger.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.CallToolResult
-import io.modelcontextprotocol.kotlin.sdk.PromptMessageContent
-import io.modelcontextprotocol.kotlin.sdk.TextContent
-import io.modelcontextprotocol.kotlin.sdk.Tool
+import io.modelcontextprotocol.kotlin.sdk.server.ClientConnection
 import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.ContentBlock
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.serializer
 import net.portswigger.mcp.schema.asInputSchema
 import kotlin.experimental.ExperimentalTypeInference
@@ -14,32 +17,31 @@ import kotlin.experimental.ExperimentalTypeInference
 @OptIn(InternalSerializationApi::class)
 inline fun <reified I : Any> Server.mcpTool(
     description: String,
-    crossinline execute: I.() -> List<PromptMessageContent>
+    crossinline execute: I.() -> List<ContentBlock>
 ) {
     val toolName = I::class.simpleName?.toLowerSnakeCase() ?: error("Couldn't find name for ${I::class}")
+    val serializer = I::class.serializer()
+    val inputSchema = I::class.asInputSchema()
 
-    addTool(
-        name = toolName,
-        description = description,
-        inputSchema = I::class.asInputSchema(),
-        handler = { request ->
-            try {
-                CallToolResult(
-                    content = execute(
-                        Json.decodeFromJsonElement(
-                            I::class.serializer(),
-                            request.arguments
-                        )
+    val handler: suspend (ClientConnection, CallToolRequest) -> CallToolResult = { _, request ->
+        try {
+            CallToolResult(
+                content = execute(
+                    Json.decodeFromJsonElement(
+                        serializer,
+                        request.params.arguments ?: JsonObject(emptyMap())
                     )
                 )
-            } catch (e: Exception) {
-                CallToolResult(
-                    content = listOf(TextContent("Error: ${e.message}")),
-                    isError = true
-                )
-            }
+            )
+        } catch (e: Exception) {
+            CallToolResult(
+                content = listOf(TextContent("Error: ${e.message}")),
+                isError = true
+            )
         }
-    )
+    }
+
+    addTool(name = toolName, description = description, inputSchema = inputSchema, handler = handler)
 }
 
 @OptIn(ExperimentalTypeInference::class)
@@ -114,18 +116,12 @@ inline fun <reified I : Paginated> Server.mcpPaginatedTool(
 inline fun Server.mcpTool(
     name: String,
     description: String,
-    crossinline execute: () -> List<PromptMessageContent>
+    crossinline execute: () -> List<ContentBlock>
 ) {
-    addTool(
-        name = name,
-        description = description,
-        inputSchema = Tool.Input(),
-        handler = {
-            CallToolResult(
-                content = execute()
-            )
-        }
-    )
+    val handler: suspend (ClientConnection, CallToolRequest) -> CallToolResult = { _, _ ->
+        CallToolResult(content = execute())
+    }
+    addTool(name = name, description = description, inputSchema = ToolSchema(), handler = handler)
 }
 
 inline fun Server.mcpTool(
@@ -133,16 +129,10 @@ inline fun Server.mcpTool(
     description: String,
     crossinline execute: () -> String
 ) {
-    addTool(
-        name = name,
-        description = description,
-        inputSchema = Tool.Input(),
-        handler = {
-            CallToolResult(
-                content = listOf(TextContent(execute()))
-            )
-        }
-    )
+    val handler: suspend (ClientConnection, CallToolRequest) -> CallToolResult = { _, _ ->
+        CallToolResult(content = listOf(TextContent(execute())))
+    }
+    addTool(name = name, description = description, inputSchema = ToolSchema(), handler = handler)
 }
 
 fun String.toLowerSnakeCase(): String {
@@ -157,4 +147,3 @@ interface Paginated {
     val count: Int
     val offset: Int
 }
-

--- a/src/main/kotlin/net/portswigger/mcp/tools/McpTool.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/McpTool.kt
@@ -57,10 +57,7 @@ inline fun <reified I : Any> Server.mcpTool(
     })
 }
 
-@OptIn(ExperimentalTypeInference::class)
-@OverloadResolutionByLambdaReturnType
-@JvmName("mcpToolUnit")
-inline fun <reified I : Any> Server.mcpTool(
+inline fun <reified I : Any> Server.mcpUnitTool(
     description: String,
     crossinline execute: I.() -> Unit
 ) {

--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -169,19 +169,19 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
         response?.toString() ?: "<no response>"
     }
 
-    mcpTool<CreateRepeaterTab>("Creates an HTTP/1.1 Repeater tab with the specified raw HTTP request and optional tab name. Make sure to use carriage returns appropriately. Prefer create_repeater_tab_http2 for modern web targets that speak HTTP/2.") {
+    mcpUnitTool<CreateRepeaterTab>("Creates an HTTP/1.1 Repeater tab with the specified raw HTTP request and optional tab name. Make sure to use carriage returns appropriately. Prefer create_repeater_tab_http2 for modern web targets that speak HTTP/2.") {
         val fixedContent = normalizeHttpContent(content)
         val request = HttpRequest.httpRequest(toMontoyaService(), fixedContent)
         api.repeater().sendToRepeater(request, tabName)
     }
 
-    mcpTool<CreateRepeaterTabHttp2>("Creates an HTTP/2 Repeater tab with the specified HTTP/2 request and optional tab name. Use this by default for modern web targets. Do NOT pass headers to the body parameter.") {
+    mcpUnitTool<CreateRepeaterTabHttp2>("Creates an HTTP/2 Repeater tab with the specified HTTP/2 request and optional tab name. Use this by default for modern web targets. Do NOT pass headers to the body parameter.") {
         val headerList = buildHttp2HeaderList(pseudoHeaders, headers)
         val request = HttpRequest.http2Request(toMontoyaService(), headerList, requestBody)
         api.repeater().sendToRepeater(request, tabName)
     }
 
-    mcpTool<SendToIntruder>("Sends an HTTP request to Intruder with the specified HTTP request and optional tab name. Make sure to use carriage returns appropriately.") {
+    mcpUnitTool<SendToIntruder>("Sends an HTTP request to Intruder with the specified HTTP request and optional tab name. Make sure to use carriage returns appropriately.") {
         val fixedContent = normalizeHttpContent(content)
         val request = HttpRequest.httpRequest(toMontoyaService(), fixedContent)
         api.intruder().sendToIntruder(request, tabName)

--- a/src/test/kotlin/net/portswigger/mcp/ProxyEndToEndTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/ProxyEndToEndTest.kt
@@ -5,7 +5,7 @@ import burp.api.montoya.logging.Logging
 import burp.api.montoya.persistence.PersistedObject
 import io.mockk.every
 import io.mockk.mockk
-import io.modelcontextprotocol.kotlin.sdk.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import net.portswigger.mcp.config.McpConfig

--- a/src/test/kotlin/net/portswigger/mcp/ProxyEndToEndTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/ProxyEndToEndTest.kt
@@ -159,7 +159,7 @@ class ProxyEndToEndTest {
         runBlocking {
             val result = client.callTool("url_encode", mapOf("content" to "hello world"))
             assertNotNull(result, "Tool call result should not be null")
-            assertFalse(result?.isError ?: true, "Tool call should not return an error")
+            assertFalse(result?.isError ?: false, "Tool call should not return an error")
             assertTrue(result?.content?.first() is TextContent, "Result should contain TextContent")
         }
     }

--- a/src/test/kotlin/net/portswigger/mcp/TestSseMcpClient.kt
+++ b/src/test/kotlin/net/portswigger/mcp/TestSseMcpClient.kt
@@ -3,9 +3,12 @@ package net.portswigger.mcp
 import io.ktor.client.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.sse.*
-import io.modelcontextprotocol.kotlin.sdk.*
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.client.SseClientTransport
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.EmptyResult
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
 import org.slf4j.LoggerFactory
 
 class TestSseMcpClient {
@@ -31,7 +34,7 @@ class TestSseMcpClient {
             connected = true
 
             val toolsResult = mcp.listTools()
-            tools = toolsResult?.tools ?: emptyList()
+            tools = toolsResult.tools
             println("Connected to server with tools: ${tools.joinToString(", ") { it.name }}")
         } catch (e: Exception) {
             println("Failed to connect to MCP server: $e")
@@ -41,7 +44,7 @@ class TestSseMcpClient {
 
     fun isConnected(): Boolean = connected
 
-    suspend fun ping(): EmptyRequestResult {
+    suspend fun ping(): EmptyResult {
         try {
             val pingRequest = mcp.ping()
             logger.info("Ping sent: $pingRequest")
@@ -55,7 +58,7 @@ class TestSseMcpClient {
     suspend fun listTools(): List<Tool> {
         try {
             val toolsResult = mcp.listTools()
-            tools = toolsResult?.tools ?: emptyList()
+            tools = toolsResult.tools
             logger.info("Tools listed: ${tools.joinToString(", ") { it.name }}")
             return tools
         } catch (e: Exception) {
@@ -64,7 +67,7 @@ class TestSseMcpClient {
         }
     }
 
-    suspend fun callTool(toolName: String, arguments: Map<String, Any>): CallToolResultBase? {
+    suspend fun callTool(toolName: String, arguments: Map<String, Any>): CallToolResult? {
         try {
             return mcp.callTool(toolName, arguments)
         } catch (e: Exception) {

--- a/src/test/kotlin/net/portswigger/mcp/TestStdioMcpClient.kt
+++ b/src/test/kotlin/net/portswigger/mcp/TestStdioMcpClient.kt
@@ -1,11 +1,11 @@
 package net.portswigger.mcp
 
-import io.modelcontextprotocol.kotlin.sdk.CallToolResultBase
-import io.modelcontextprotocol.kotlin.sdk.EmptyRequestResult
-import io.modelcontextprotocol.kotlin.sdk.Implementation
-import io.modelcontextprotocol.kotlin.sdk.Tool
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.client.StdioClientTransport
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.EmptyResult
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
 import kotlinx.io.asSink
 import kotlinx.io.asSource
 import kotlinx.io.buffered
@@ -27,7 +27,7 @@ class TestStdioMcpClient {
         logger.info("Connected to server")
     }
 
-    suspend fun ping(): EmptyRequestResult {
+    suspend fun ping(): EmptyResult {
         return mcp.ping()
     }
 
@@ -35,7 +35,7 @@ class TestStdioMcpClient {
         return mcp.listTools().tools
     }
 
-    suspend fun callTool(toolName: String, arguments: Map<String, Any>): CallToolResultBase? {
+    suspend fun callTool(toolName: String, arguments: Map<String, Any>): CallToolResult? {
         return mcp.callTool(toolName, arguments)
     }
 

--- a/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
@@ -22,8 +22,8 @@ import io.mockk.*
 import java.net.InetAddress
 import java.time.ZonedDateTime
 import java.util.Optional
-import io.modelcontextprotocol.kotlin.sdk.CallToolResultBase
-import io.modelcontextprotocol.kotlin.sdk.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
@@ -81,7 +81,7 @@ class ToolsKtTest {
         mockkStatic(HttpRequest::class)
     }
 
-    private fun CallToolResultBase?.expectTextContent(
+    private fun CallToolResult?.expectTextContent(
         expected: String? = null,
     ): String {
         assertNotNull(this, "Tool result cannot be null")


### PR DESCRIPTION
## Summary

- Bumps `io.modelcontextprotocol:kotlin-sdk` from 0.7.4 to 0.15.0
- Upgrades Kotlin to 2.4.0, required by SDK 0.15.0 metadata
- Keeps the existing SDK API migration from 0.12.0 and resolves Kotlin 2.4 overload ambiguity for side-effect-only tools
- Rebuilds the bundled `mcp-proxy` with SDK 0.15.0 and Kotlin 2.4.0
- Tracks the proxy source upgrade in PortSwigger/mcp-proxy#5
- Updates the proxy to close an existing SDK transport before reconnecting, as SDK 0.15.0 now rejects connecting an already-connected protocol
- Uses the current `StdioServerTransport` constructor

## Impact

The Burp MCP server and bundled stdio proxy now use Kotlin MCP SDK 0.15.0. Proxy reconnection remains functional with the SDK's stricter connection lifecycle.

## Validation

- [x] `mcp-proxy: ./gradlew test shadowJar --no-daemon`
- [x] `mcp-server: ./gradlew test --rerun-tasks --no-daemon`
- [x] Proxy end-to-end list-tools, ping, and tool-call tests pass against the rebuilt proxy JAR
