### PR TITLE
Fix MCP tool contracts

### DIFF
--- a/src/main/kotlin/net/portswigger/mcp/schema/JsonSchema.kt
+++ b/src/main/kotlin/net/portswigger/mcp/schema/JsonSchema.kt
@@ -2,10 +2,13 @@ package net.portswigger.mcp.schema
 
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
 import kotlin.reflect.KClass
 import kotlin.reflect.full.memberProperties
+import kotlin.reflect.full.primaryConstructor
 
 fun getJsonSchemaForProperty(kType: kotlin.reflect.KType): JsonElement {
     return when (kType.classifier) {
@@ -47,11 +50,24 @@ fun getJsonSchemaForProperty(kType: kotlin.reflect.KType): JsonElement {
 fun KClass<*>.asInputSchema(): ToolSchema {
     val properties = mutableMapOf<String, JsonElement>()
     val required = mutableListOf<String>()
+    val parameters = primaryConstructor?.parameters?.associateBy { it.name }.orEmpty()
 
     for (prop in memberProperties) {
-        properties[prop.name] = getJsonSchemaForProperty(prop.returnType)
+        val schema = getJsonSchemaForProperty(prop.returnType).jsonObject.toMutableMap()
+        if (prop.returnType.isMarkedNullable) {
+            schema["type"] = JsonArray(listOf(schema.getValue("type"), JsonPrimitive("null")))
+        }
+        when (prop.name) {
+            "targetPort" -> {
+                schema["minimum"] = JsonPrimitive(1)
+                schema["maximum"] = JsonPrimitive(65535)
+            }
+            "count" -> schema["minimum"] = JsonPrimitive(1)
+            "offset", "length" -> schema["minimum"] = JsonPrimitive(0)
+        }
+        properties[prop.name] = JsonObject(schema)
 
-        if (!prop.returnType.isMarkedNullable) {
+        if (parameters[prop.name]?.isOptional == false) {
             required.add(prop.name)
         }
     }

--- a/src/main/kotlin/net/portswigger/mcp/tools/McpTool.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/McpTool.kt
@@ -8,11 +8,61 @@ import io.modelcontextprotocol.kotlin.sdk.types.ContentBlock
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.serializer
 import net.portswigger.mcp.schema.asInputSchema
 import kotlin.experimental.ExperimentalTypeInference
+import kotlin.reflect.KClass
+import kotlin.reflect.full.memberProperties
+
+@PublishedApi
+internal class McpToolException(message: String) : IllegalArgumentException(message)
+
+fun mcpError(message: String): Nothing = throw McpToolException(message)
+
+@PublishedApi
+internal val ToolJson = Json { ignoreUnknownKeys = true }
+
+@PublishedApi
+internal fun <I : Any> coerceWholeNumberArguments(arguments: JsonObject, inputClass: KClass<I>): JsonObject {
+    val integerProperties = inputClass.memberProperties
+        .filter { it.returnType.classifier == Int::class || it.returnType.classifier == Long::class }
+        .associate { it.name to it.returnType.classifier }
+
+    return JsonObject(arguments.mapValues { (name, value) ->
+        val primitive = value as? JsonPrimitive
+        val classifier = integerProperties[name]
+        if (primitive == null || primitive.isString || classifier == null) return@mapValues value
+
+        val integer = primitive.content.toBigDecimalOrNull()?.let {
+            try { it.toBigIntegerExact() } catch (_: ArithmeticException) { null }
+        } ?: return@mapValues value
+
+        when (classifier) {
+            Int::class -> integer.toIntExactOrNull()?.let(::JsonPrimitive) ?: value
+            Long::class -> integer.toLongExactOrNull()?.let(::JsonPrimitive) ?: value
+            else -> value
+        }
+    })
+}
+
+private fun java.math.BigInteger.toIntExactOrNull() = try { intValueExact() } catch (_: ArithmeticException) { null }
+private fun java.math.BigInteger.toLongExactOrNull() = try { longValueExact() } catch (_: ArithmeticException) { null }
+
+@PublishedApi
+internal fun toolErrorResult(toolName: String, error: Exception): CallToolResult {
+    val detail = error.message?.substringBefore(" at path:") ?: error::class.simpleName ?: "unknown error"
+    val message = when (error) {
+        is McpToolException -> detail
+        is SerializationException, is IllegalArgumentException ->
+            "Invalid arguments for '$toolName': $detail. Check the tool schema from tools/list and retry."
+        else -> "Tool '$toolName' failed: $detail. Check Burp's extension output for details."
+    }
+    return CallToolResult(content = listOf(TextContent(message)), isError = true)
+}
 
 @OptIn(InternalSerializationApi::class)
 inline fun <reified I : Any> Server.mcpTool(
@@ -27,18 +77,18 @@ inline fun <reified I : Any> Server.mcpTool(
         try {
             CallToolResult(
                 content = execute(
-                    Json.decodeFromJsonElement(
+                    ToolJson.decodeFromJsonElement(
                         serializer,
-                        request.params.arguments ?: JsonObject(emptyMap())
+                        coerceWholeNumberArguments(
+                            request.params.arguments ?: JsonObject(emptyMap()),
+                            I::class
+                        )
                     )
                 ),
                 isError = false
             )
         } catch (e: Exception) {
-            CallToolResult(
-                content = listOf(TextContent("Error: ${e.message}")),
-                isError = true
-            )
+            toolErrorResult(toolName, e)
         }
     }
 
@@ -83,7 +133,7 @@ inline fun <reified I : Paginated, J : Any> Server.mcpPaginatedTool(
             }
 
             else -> {
-                val upperLimit = (offset + count).coerceAtMost(items.size)
+                val upperLimit = (offset.toLong() + count).coerceAtMost(items.size.toLong()).toInt()
 
                 items.subList(offset, upperLimit)
                     .joinToString(separator = "\n\n", transform = mapper)
@@ -117,7 +167,11 @@ inline fun Server.mcpTool(
     crossinline execute: () -> List<ContentBlock>
 ) {
     val handler: suspend (ClientConnection, CallToolRequest) -> CallToolResult = { _, _ ->
-        CallToolResult(content = execute(), isError = false)
+        try {
+            CallToolResult(content = execute(), isError = false)
+        } catch (e: Exception) {
+            toolErrorResult(name, e)
+        }
     }
     addTool(name = name, description = description, inputSchema = ToolSchema(), handler = handler)
 }
@@ -128,7 +182,11 @@ inline fun Server.mcpTool(
     crossinline execute: () -> String
 ) {
     val handler: suspend (ClientConnection, CallToolRequest) -> CallToolResult = { _, _ ->
-        CallToolResult(content = listOf(TextContent(execute())), isError = false)
+        try {
+            CallToolResult(content = listOf(TextContent(execute())), isError = false)
+        } catch (e: Exception) {
+            toolErrorResult(name, e)
+        }
     }
     addTool(name = name, description = description, inputSchema = ToolSchema(), handler = handler)
 }

--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -22,6 +22,7 @@ import net.portswigger.mcp.security.HttpRequestSecurity
 import net.portswigger.mcp.security.filterConfigCredentials
 import java.awt.KeyboardFocusManager
 import java.util.regex.Pattern
+import java.util.regex.PatternSyntaxException
 import javax.swing.JTextArea
 
 private suspend fun checkDataAccessOrDeny(
@@ -116,7 +117,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
         }
         if (!allowed) {
             api.logging().logToOutput("MCP HTTP request denied: $targetHostname:$targetPort")
-            return@mcpTool "Send HTTP request denied by Burp Suite"
+            mcpError("HTTP request to $targetHostname:$targetPort was denied in Burp Suite. Approve the target in Burp and retry.")
         }
 
         api.logging().logToOutput("MCP HTTP/1.1 request: $targetHostname:$targetPort")
@@ -126,7 +127,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
         val request = HttpRequest.httpRequest(toMontoyaService(), fixedContent)
         val response = api.http().sendRequest(request)
 
-        response?.toString() ?: "<no response>"
+        response?.toString() ?: mcpError("No HTTP response was received from $targetHostname:$targetPort. Check the target and Burp network settings.")
     }
 
     mcpTool<SendHttp2Request>("Issues an HTTP/2 request and returns the response. Do NOT pass headers to the body parameter.") {
@@ -149,7 +150,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
         }
         if (!allowed) {
             api.logging().logToOutput("MCP HTTP request denied: $targetHostname:$targetPort")
-            return@mcpTool "Send HTTP request denied by Burp Suite"
+            mcpError("HTTP request to $targetHostname:$targetPort was denied in Burp Suite. Approve the target in Burp and retry.")
         }
 
         api.logging().logToOutput("MCP HTTP/2 request: $targetHostname:$targetPort")
@@ -159,7 +160,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
         val request = HttpRequest.http2Request(toMontoyaService(), headerList, requestBody)
         val response = api.http().sendRequest(request, HttpMode.HTTP_2)
 
-        response?.toString() ?: "<no response>"
+        response?.toString() ?: mcpError("No HTTP response was received from $targetHostname:$targetPort. Check the target and Burp network settings.")
     }
 
     mcpUnitTool<CreateRepeaterTab>("Creates an HTTP/1.1 Repeater tab with the specified raw HTTP request and optional tab name. Make sure to use carriage returns appropriately. Prefer create_repeater_tab_http2 for modern web targets that speak HTTP/2.") {
@@ -234,7 +235,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
 
             "Project configuration has been applied"
         } else {
-            toolingDisabledMessage
+            mcpError(toolingDisabledMessage)
         }
     }
 
@@ -246,7 +247,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
 
             "User configuration has been applied"
         } else {
-            toolingDisabledMessage
+            mcpError(toolingDisabledMessage)
         }
     }
 
@@ -302,7 +303,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
             checkDataAccessOrDeny(DataAccessType.HTTP_HISTORY, config, api, "HTTP history")
         }
         if (!allowed) {
-            return@mcpPaginatedTool sequenceOf("HTTP history access denied by Burp Suite")
+            mcpError("HTTP history access was denied in Burp Suite. Allow HTTP history access and retry.")
         }
 
         api.proxy().history().asSequence().map { encodeHistoryItem(it.toSerializableForm()) }
@@ -313,7 +314,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
             checkDataAccessOrDeny(DataAccessType.HTTP_HISTORY, config, api, "HTTP history")
         }
         if (!allowed) {
-            return@mcpPaginatedTool sequenceOf("HTTP history access denied by Burp Suite")
+            mcpError("HTTP history access was denied in Burp Suite. Allow HTTP history access and retry.")
         }
 
         val compiledRegex = Pattern.compile(regex)
@@ -326,7 +327,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
             checkDataAccessOrDeny(DataAccessType.ORGANIZER, config, api, "Organizer")
         }
         if (!allowed) {
-            return@mcpPaginatedTool sequenceOf("Organizer access denied by Burp Suite")
+            mcpError("Organizer access was denied in Burp Suite. Allow Organizer access and retry.")
         }
 
         api.organizer().items().asSequence().map { encodeHistoryItem(it.toSerializableForm()) }
@@ -337,7 +338,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
             checkDataAccessOrDeny(DataAccessType.ORGANIZER, config, api, "Organizer")
         }
         if (!allowed) {
-            return@mcpPaginatedTool sequenceOf("Organizer access denied by Burp Suite")
+            mcpError("Organizer access was denied in Burp Suite. Allow Organizer access and retry.")
         }
 
         val compiledRegex = Pattern.compile(regex)
@@ -350,7 +351,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
             checkDataAccessOrDeny(DataAccessType.WEBSOCKET_HISTORY, config, api, "WebSocket history")
         }
         if (!allowed) {
-            return@mcpPaginatedTool sequenceOf("WebSocket history access denied by Burp Suite")
+            mcpError("WebSocket history access was denied in Burp Suite. Allow WebSocket history access and retry.")
         }
 
         api.proxy().webSocketHistory().asSequence()
@@ -362,7 +363,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
             checkDataAccessOrDeny(DataAccessType.WEBSOCKET_HISTORY, config, api, "WebSocket history")
         }
         if (!allowed) {
-            return@mcpPaginatedTool sequenceOf("WebSocket history access denied by Burp Suite")
+            mcpError("WebSocket history access was denied in Burp Suite. Allow WebSocket history access and retry.")
         }
 
         val compiledRegex = Pattern.compile(regex)
@@ -387,14 +388,14 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
     }
 
     mcpTool("get_active_editor_contents", "Outputs the contents of the user's active message editor") {
-        getActiveEditor(api)?.text ?: "<No active editor>"
+        getActiveEditor(api)?.text ?: mcpError("No Burp message editor is active. Focus a request or response editor and retry.")
     }
 
     mcpTool<SetActiveEditorContents>("Sets the content of the user's active message editor") {
-        val editor = getActiveEditor(api) ?: return@mcpTool "<No active editor>"
+        val editor = getActiveEditor(api) ?: mcpError("No Burp message editor is active. Focus an editable request editor and retry.")
 
         if (!editor.isEditable) {
-            return@mcpTool "<Current editor is not editable>"
+            mcpError("The active Burp message editor is read-only. Focus an editable request editor and retry.")
         }
 
         editor.text = text
@@ -426,13 +427,53 @@ interface HttpServiceParams {
     fun toMontoyaService(): HttpService = HttpService.httpService(targetHostname, targetPort, usesHttps)
 }
 
+private fun validateHttpService(hostname: String, port: Int) {
+    require(hostname.isNotBlank()) { "targetHostname must not be blank" }
+    require(port in 1..65535) { "targetPort must be between 1 and 65535" }
+}
+
+private fun validatePagination(count: Int, offset: Int) {
+    require(count > 0) { "count must be greater than 0" }
+    require(offset >= 0) { "offset must be 0 or greater" }
+}
+
+private fun validateRegex(regex: String) {
+    try {
+        Pattern.compile(regex)
+    } catch (error: PatternSyntaxException) {
+        throw IllegalArgumentException("regex is invalid at index ${error.index}: ${error.description}")
+    }
+}
+
+private fun validateHttp2(pseudoHeaders: Map<String, String>, headers: Map<String, String>) {
+    val normalized = pseudoHeaders.mapKeys { it.key.removePrefix(":").lowercase() }
+    require(normalized.size == pseudoHeaders.size) { "pseudoHeaders must not contain duplicate names with and without ':'" }
+    require(normalized.keys.all { it in setOf("method", "scheme", "path", "authority", "protocol") }) {
+        "pseudoHeaders may only contain :method, :scheme, :path, :authority, and :protocol"
+    }
+    require(normalized.values.none(String::isBlank)) { "pseudoHeaders values must not be blank" }
+    require(headers.keys.none { it.startsWith(":") }) { "HTTP/2 pseudo-headers belong in pseudoHeaders, not headers" }
+    require(!normalized["method"].isNullOrBlank()) { "pseudoHeaders must include a non-blank :method" }
+    require(!normalized["authority"].isNullOrBlank()) { "pseudoHeaders must include a non-blank :authority" }
+
+    val extendedConnect = normalized["protocol"] != null
+    if (!normalized["method"].equals("CONNECT", ignoreCase = true) || extendedConnect) {
+        require(normalized["scheme"] in setOf("http", "https")) { "pseudoHeaders must include :scheme set to 'http' or 'https'" }
+        require(normalized["path"]?.let { it == "*" || it.startsWith("/") } == true) {
+            "pseudoHeaders must include :path starting with '/' (or '*')"
+        }
+    }
+}
+
 @Serializable
 data class SendHttp1Request(
     val content: String,
     override val targetHostname: String,
     override val targetPort: Int,
     override val usesHttps: Boolean
-) : HttpServiceParams
+) : HttpServiceParams {
+    init { validateHttpService(targetHostname, targetPort) }
+}
 
 @Serializable
 data class SendHttp2Request(
@@ -442,36 +483,50 @@ data class SendHttp2Request(
     override val targetHostname: String,
     override val targetPort: Int,
     override val usesHttps: Boolean
-) : HttpServiceParams
+) : HttpServiceParams {
+    init {
+        validateHttpService(targetHostname, targetPort)
+        validateHttp2(pseudoHeaders, headers)
+    }
+}
 
 @Serializable
 data class CreateRepeaterTab(
-    val tabName: String?,
+    val tabName: String? = null,
     val content: String,
     override val targetHostname: String,
     override val targetPort: Int,
     override val usesHttps: Boolean
-) : HttpServiceParams
+) : HttpServiceParams {
+    init { validateHttpService(targetHostname, targetPort) }
+}
 
 @Serializable
 data class CreateRepeaterTabHttp2(
-    val tabName: String?,
+    val tabName: String? = null,
     val pseudoHeaders: Map<String, String>,
     val headers: Map<String, String>,
     val requestBody: String,
     override val targetHostname: String,
     override val targetPort: Int,
     override val usesHttps: Boolean
-) : HttpServiceParams
+) : HttpServiceParams {
+    init {
+        validateHttpService(targetHostname, targetPort)
+        validateHttp2(pseudoHeaders, headers)
+    }
+}
 
 @Serializable
 data class SendToIntruder(
-    val tabName: String?,
+    val tabName: String? = null,
     val content: String,
     override val targetHostname: String,
     override val targetPort: Int,
     override val usesHttps: Boolean
-) : HttpServiceParams
+) : HttpServiceParams {
+    init { validateHttpService(targetHostname, targetPort) }
+}
 
 @Serializable
 data class UrlEncode(val content: String)
@@ -486,7 +541,12 @@ data class Base64Encode(val content: String)
 data class Base64Decode(val content: String)
 
 @Serializable
-data class GenerateRandomString(val length: Int, val characterSet: String)
+data class GenerateRandomString(val length: Int, val characterSet: String) {
+    init {
+        require(length >= 0) { "length must be 0 or greater" }
+        require(characterSet.isNotEmpty() || length == 0) { "characterSet must not be empty when length is greater than 0" }
+    }
+}
 
 @Serializable
 data class SetProjectOptions(val json: String)
@@ -504,26 +564,49 @@ data class SetProxyInterceptState(val intercepting: Boolean)
 data class SetActiveEditorContents(val text: String)
 
 @Serializable
-data class GetScannerIssues(override val count: Int, override val offset: Int) : Paginated
+data class GetScannerIssues(override val count: Int, override val offset: Int) : Paginated {
+    init { validatePagination(count, offset) }
+}
 
 @Serializable
-data class GetProxyHttpHistory(override val count: Int, override val offset: Int) : Paginated
+data class GetProxyHttpHistory(override val count: Int, override val offset: Int) : Paginated {
+    init { validatePagination(count, offset) }
+}
 
 @Serializable
-data class GetProxyHttpHistoryRegex(val regex: String, override val count: Int, override val offset: Int) : Paginated
+data class GetProxyHttpHistoryRegex(val regex: String, override val count: Int, override val offset: Int) : Paginated {
+    init {
+        validatePagination(count, offset)
+        validateRegex(regex)
+    }
+}
 
 @Serializable
-data class GetOrganizerItems(override val count: Int, override val offset: Int) : Paginated
+data class GetOrganizerItems(override val count: Int, override val offset: Int) : Paginated {
+    init { validatePagination(count, offset) }
+}
 
 @Serializable
-data class GetOrganizerItemsRegex(val regex: String, override val count: Int, override val offset: Int) : Paginated
+data class GetOrganizerItemsRegex(val regex: String, override val count: Int, override val offset: Int) : Paginated {
+    init {
+        validatePagination(count, offset)
+        validateRegex(regex)
+    }
+}
 
 @Serializable
-data class GetProxyWebsocketHistory(override val count: Int, override val offset: Int) : Paginated
+data class GetProxyWebsocketHistory(override val count: Int, override val offset: Int) : Paginated {
+    init { validatePagination(count, offset) }
+}
 
 @Serializable
 data class GetProxyWebsocketHistoryRegex(val regex: String, override val count: Int, override val offset: Int) :
-    Paginated
+    Paginated {
+    init {
+        validatePagination(count, offset)
+        validateRegex(regex)
+    }
+}
 
 @Serializable
 data class GenerateCollaboratorPayload(

--- a/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import net.portswigger.mcp.KtorServerManager
@@ -154,10 +155,115 @@ class ToolsKtTest {
 
     private fun findAvailablePort() = ServerSocket(0).use { it.localPort }
 
+    private fun requiredArgument(name: String): Any = when (name) {
+        "targetHostname" -> "example.com"
+        "targetPort" -> 443.0
+        "usesHttps" -> true
+        "pseudoHeaders" -> mapOf(
+            "method" to "GET", "scheme" to "https", "path" to "/", "authority" to "example.com"
+        )
+        "headers" -> emptyMap<String, String>()
+        "content" -> "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
+        "requestBody", "text" -> ""
+        "json" -> "{}"
+        "regex" -> ".*"
+        "count", "length" -> 1.0
+        "offset" -> 0.0
+        "characterSet" -> "a"
+        "running", "intercepting" -> false
+        else -> "value"
+    }
+
     @AfterEach
     fun tearDown() {
         runBlocking { if (client.isConnected()) client.close() }
         serverManager.stop {}
+    }
+
+    @Test
+    fun `invalid constrained arguments return actionable MCP errors`() = runBlocking {
+        val validHttp2 = mapOf(
+            "pseudoHeaders" to mapOf(
+                "method" to "GET", "scheme" to "https", "path" to "/", "authority" to "example.com"
+            ),
+            "headers" to emptyMap<String, String>(),
+            "requestBody" to "",
+            "targetHostname" to "example.com",
+            "targetPort" to 443,
+            "usesHttps" to true
+        )
+        val cases = listOf(
+            Triple(
+                "send_http1_request",
+                mapOf("content" to "GET / HTTP/1.1\r\n\r\n", "targetHostname" to "example.com", "targetPort" to 0, "usesHttps" to false),
+                "targetPort must be between 1 and 65535"
+            ),
+            Triple("get_proxy_http_history", mapOf("count" to 0, "offset" to 0), "count must be greater than 0"),
+            Triple("get_proxy_http_history", mapOf("count" to 1, "offset" to -1), "offset must be 0 or greater"),
+            Triple("get_proxy_http_history_regex", mapOf("regex" to "[", "count" to 1, "offset" to 0), "regex is invalid at index"),
+            Triple(
+                "send_http2_request",
+                validHttp2 + ("pseudoHeaders" to mapOf("method" to "GET", "scheme" to "https", "authority" to "example.com")),
+                "pseudoHeaders must include :path"
+            ),
+            Triple(
+                "send_http2_request",
+                validHttp2 + ("pseudoHeaders" to mapOf("scheme" to "https", "path" to "/", "authority" to "example.com")),
+                "pseudoHeaders must include a non-blank :method"
+            ),
+            Triple(
+                "send_http2_request",
+                validHttp2 + ("pseudoHeaders" to mapOf("method" to "GET", "scheme" to "https", "path" to "/")),
+                "pseudoHeaders must include a non-blank :authority"
+            ),
+            Triple(
+                "send_http2_request",
+                validHttp2 + ("headers" to mapOf(":path" to "/")),
+                "pseudo-headers belong in pseudoHeaders"
+            )
+        )
+
+        cases.forEach { (tool, arguments, expected) ->
+            val result = client.callTool(tool, arguments)
+            assertTrue(result?.isError == true, "$tool should return an MCP error")
+            val message = result.expectTextContent()
+            assertTrue(message.startsWith("Invalid arguments for '$tool':"), message)
+            assertTrue(message.contains(expected), "$tool should explain: $expected")
+            assertTrue(message.endsWith("Check the tool schema from tools/list and retry."), message)
+        }
+    }
+
+    @Test
+    fun `schemas advertise runtime numeric and nullable constraints`() = runBlocking {
+        val tools = client.listTools().associateBy { it.name }
+        fun property(tool: String, name: String) = tools.getValue(tool).inputSchema.properties!!.getValue(name).jsonObject
+
+        listOf("send_http1_request", "send_http2_request", "create_repeater_tab", "create_repeater_tab_http2", "send_to_intruder")
+            .forEach { tool ->
+                assertEquals("1", property(tool, "targetPort").getValue("minimum").jsonPrimitive.content, tool)
+                assertEquals("65535", property(tool, "targetPort").getValue("maximum").jsonPrimitive.content, tool)
+            }
+        listOf(
+            "get_proxy_http_history", "get_proxy_http_history_regex", "get_organizer_items",
+            "get_organizer_items_regex", "get_proxy_websocket_history", "get_proxy_websocket_history_regex"
+        ).forEach { tool ->
+            assertEquals("1", property(tool, "count").getValue("minimum").jsonPrimitive.content, tool)
+            assertEquals("0", property(tool, "offset").getValue("minimum").jsonPrimitive.content, tool)
+        }
+        assertEquals("0", property("generate_random_string", "length").getValue("minimum").jsonPrimitive.content)
+
+        mapOf(
+            "create_repeater_tab" to "tabName",
+            "create_repeater_tab_http2" to "tabName",
+            "send_to_intruder" to "tabName"
+        ).forEach { (tool, name) ->
+            assertFalse(tools.getValue(tool).inputSchema.required.orEmpty().contains(name), tool)
+            assertEquals(
+                setOf("string", "null"),
+                property(tool, name).getValue("type").jsonArray.map { it.jsonPrimitive.content }.toSet(),
+                tool
+            )
+        }
     }
 
     @Nested
@@ -223,7 +329,8 @@ class ToolsKtTest {
                 )
 
                 delay(100)
-                result.expectTextContent("<no response>")
+                assertTrue(result?.isError == true)
+                assertTrue(result.expectTextContent().contains("No HTTP response was received"))
             }
         }
 
@@ -256,7 +363,7 @@ class ToolsKtTest {
                         "headers" to Json.encodeToJsonElement(headers),
                         "requestBody" to requestBody,
                         "targetHostname" to "example.com",
-                        "targetPort" to 443,
+                        "targetPort" to 443.0,
                         "usesHttps" to true
                     )
                 )
@@ -292,7 +399,9 @@ class ToolsKtTest {
             every { api.http() } returns httpService
             every { httpService.sendRequest(any(), HttpMode.HTTP_2) } returns null
 
-            val pseudoHeaders = mapOf("method" to "GET", "path" to "/test")
+            val pseudoHeaders = mapOf(
+                "method" to "GET", "scheme" to "https", "path" to "/test", "authority" to "example.com"
+            )
             val headers = mapOf("User-Agent" to "Test Agent")
 
             runBlocking {
@@ -308,7 +417,8 @@ class ToolsKtTest {
                 )
 
                 delay(100)
-                result.expectTextContent("<no response>")
+                assertTrue(result?.isError == true)
+                assertTrue(result.expectTextContent().contains("No HTTP response was received"))
             }
         }
         
@@ -351,11 +461,7 @@ class ToolsKtTest {
                 .filter { it.name().startsWith(":") }
                 .map { it.name() }
             
-            val expectedOrder = listOf(":scheme", ":method", ":path", ":authority")
-            for (i in 0 until minOf(expectedOrder.size, pseudoHeaderNames.size)) {
-                assertEquals(expectedOrder[i], pseudoHeaderNames[i],
-                    "Pseudo headers should follow the order: scheme, method, path, authority")
-            }
+            assertEquals(listOf(":scheme", ":method", ":path", ":authority"), pseudoHeaderNames)
         }
 
         @Test
@@ -397,6 +503,36 @@ class ToolsKtTest {
             val pseudoHeaderNames = headersSlot.captured.filter { it.name().startsWith(":") }.map { it.name() }
             assertEquals(listOf(":scheme", ":method", ":path", ":authority"), pseudoHeaderNames)
             assertTrue(headersSlot.captured.any { it.name() == "content-type" && it.value() == "application/json" })
+        }
+
+        @Test
+        fun `create repeater tab http2 accepts schema-required fields only`() = runBlocking {
+            val repeater = mockk<burp.api.montoya.repeater.Repeater>(relaxed = true)
+            val httpRequest = mockk<HttpRequest>()
+            every { HttpRequest.http2Request(any(), any(), any<String>()) } returns httpRequest
+            every { api.repeater() } returns repeater
+
+            val tool = client.listTools().single { it.name == "create_repeater_tab_http2" }
+            assertFalse(tool.inputSchema.required.orEmpty().contains("tabName"))
+
+            val result = client.callTool(
+                "create_repeater_tab_http2", mapOf(
+                    "pseudoHeaders" to mapOf(
+                        "method" to "GET",
+                        "scheme" to "https",
+                        "path" to "/",
+                        "authority" to "example.com"
+                    ),
+                    "headers" to emptyMap<String, String>(),
+                    "requestBody" to "",
+                    "targetHostname" to "example.com",
+                    "targetPort" to 443.0,
+                    "usesHttps" to true
+                )
+            )
+
+            assertFalse(result?.isError ?: true, result.expectTextContent())
+            verify(exactly = 1) { repeater.sendToRepeater(httpRequest, null) }
         }
     }
 
@@ -544,6 +680,7 @@ class ToolsKtTest {
             }
             
             verify(exactly = 1) { taskExecutionEngine.state = TaskExecutionEngine.TaskExecutionEngineState.RUNNING }
+            verify(exactly = 0) { taskExecutionEngine.state = TaskExecutionEngine.TaskExecutionEngineState.PAUSED }
             
             clearMocks(taskExecutionEngine, answers = false)
             
@@ -559,6 +696,7 @@ class ToolsKtTest {
             }
             
             verify(exactly = 1) { taskExecutionEngine.state = TaskExecutionEngine.TaskExecutionEngineState.PAUSED }
+            verify(exactly = 0) { taskExecutionEngine.state = TaskExecutionEngine.TaskExecutionEngineState.RUNNING }
         }
         
         @Test
@@ -581,6 +719,7 @@ class ToolsKtTest {
             }
             
             verify(exactly = 1) { proxy.enableIntercept() }
+            verify(exactly = 0) { proxy.disableIntercept() }
             
             clearMocks(proxy, answers = false)
             
@@ -596,6 +735,7 @@ class ToolsKtTest {
             }
             
             verify(exactly = 1) { proxy.disableIntercept() }
+            verify(exactly = 0) { proxy.enableIntercept() }
         }
         
         @Test
@@ -632,7 +772,8 @@ class ToolsKtTest {
                 )
                 
                 delay(100)
-                result.expectTextContent("User has disabled configuration editing. They can enable it in the MCP tab in Burp by selecting 'Enable tools that can edit your config'")
+                assertTrue(result?.isError == true)
+                assertTrue(result.expectTextContent().contains("disabled configuration editing"))
             }
             
             verify(exactly = 0) { burpSuite.importProjectOptionsFromJson(any()) }
@@ -651,7 +792,8 @@ class ToolsKtTest {
                 val result = client.callTool("get_active_editor_contents", emptyMap())
                 
                 delay(100)
-                result.expectTextContent("<No active editor>")
+                assertTrue(result?.isError == true)
+                assertTrue(result.expectTextContent().contains("No Burp message editor is active"))
             }
         }
         
@@ -685,7 +827,8 @@ class ToolsKtTest {
                 )
                 
                 delay(100)
-                result.expectTextContent("<No active editor>")
+                assertTrue(result?.isError == true)
+                assertTrue(result.expectTextContent().contains("No Burp message editor is active"))
             }
         }
         
@@ -705,7 +848,8 @@ class ToolsKtTest {
                 )
                 
                 delay(100)
-                result.expectTextContent("<Current editor is not editable>")
+                assertTrue(result?.isError == true)
+                assertTrue(result.expectTextContent().contains("read-only"))
             }
         }
         
@@ -1052,6 +1196,41 @@ class ToolsKtTest {
                 val result = client.callTool("get_collaborator_interactions", emptyMap())
                 delay(100)
                 result.expectTextContent("No interactions detected")
+            }
+        }
+
+        @Test
+        fun `every advertised schema accepts a call with only required fields`() = runBlocking {
+            val tools = client.listTools()
+            assertFalse(tools.isEmpty())
+
+            val byName = tools.associateBy { it.name }
+            val scannerProperties = byName.getValue("get_scanner_issues").inputSchema.properties!!
+            assertEquals("1", scannerProperties.getValue("count").jsonObject.getValue("minimum").jsonPrimitive.content)
+            assertEquals("0", scannerProperties.getValue("offset").jsonObject.getValue("minimum").jsonPrimitive.content)
+            mapOf(
+                "generate_collaborator_payload" to "customData",
+                "get_collaborator_interactions" to "payloadId"
+            ).forEach { (tool, name) ->
+                val schema = byName.getValue(tool).inputSchema
+                assertFalse(schema.required.orEmpty().contains(name), tool)
+                assertEquals(
+                    setOf("string", "null"),
+                    schema.properties!!.getValue(name).jsonObject.getValue("type").jsonArray
+                        .map { it.jsonPrimitive.content }.toSet(),
+                    tool
+                )
+            }
+
+            tools.forEach { tool ->
+                val arguments = tool.inputSchema.required.orEmpty().associateWith(::requiredArgument)
+                val result = client.callTool(tool.name, arguments)
+                val text = result.expectTextContent()
+
+                assertFalse(
+                    result?.isError == true && text.startsWith("Invalid arguments for"),
+                    "${tool.name} rejected arguments generated from its required schema: $text"
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary

- derive required fields from Kotlin constructor defaults and advertise nullable values accurately
- validate ports, pagination values, random-string length, regexes, and HTTP/2 pseudo-headers before calling Montoya
- accept whole JSON numbers such as `443.0` for integer parameters and ignore undeclared client arguments
- return actionable MCP error results instead of exceptions or success-shaped error strings
- exercise every advertised tool using only the fields its generated schema declares as required

## Root cause

Schema generation treated Kotlin nullability as requiredness, while `kotlinx.serialization` treats constructor defaults as optionality. Nullable properties without defaults—most visibly `tabName`—were therefore advertised as optional but rejected during deserialization. Other constraints were neither represented in schemas nor checked consistently before reaching downstream APIs.

## Impact

Schema-respecting MCP clients can omit optional values safely, clients that encode whole numbers as JSON decimals remain compatible, and invalid tool calls receive an MCP error with a concrete correction instead of an exception or successful-looking string.

## Validation

- `./gradlew test`
- generated-schema integration test invokes every Community and Professional tool with required fields only
- focused coverage for integer coercion, nullable schemas, numeric constraints, regex errors, ports, pagination, and HTTP/2 pseudo-headers
- fresh assertion-quality audit completed

Closes #109
