### PR TITLE
Add first-class HTTP exchange artifacts

### DIFF
--- a/src/main/kotlin/net/portswigger/mcp/KtorServerManager.kt
+++ b/src/main/kotlin/net/portswigger/mcp/KtorServerManager.kt
@@ -14,6 +14,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.mcp
 import net.portswigger.mcp.config.McpConfig
+import net.portswigger.mcp.tools.HttpArtifactRegistry
 import net.portswigger.mcp.tools.registerTools
 import java.net.URI
 import java.util.concurrent.ExecutorService
@@ -24,6 +25,7 @@ class KtorServerManager(private val api: MontoyaApi) : ServerManager {
 
     private var server: EmbeddedServer<*, *>? = null
     private val executor: ExecutorService = Executors.newSingleThreadExecutor()
+    private val httpArtifacts = HttpArtifactRegistry(api).also { it.start() }
 
     override fun start(config: McpConfig, callback: (ServerState) -> Unit) {
         callback(ServerState.Starting)
@@ -96,7 +98,7 @@ class KtorServerManager(private val api: MontoyaApi) : ServerManager {
                         mcpServer
                     }
 
-                    mcpServer.registerTools(api, config)
+                    mcpServer.registerTools(api, config, httpArtifacts)
                 }.apply {
                     start(wait = false)
                 }
@@ -130,6 +132,7 @@ class KtorServerManager(private val api: MontoyaApi) : ServerManager {
     override fun shutdown() {
         server?.stop(1000, 5000)
         server = null
+        httpArtifacts.close()
 
         executor.shutdown()
         executor.awaitTermination(10, TimeUnit.SECONDS)

--- a/src/main/kotlin/net/portswigger/mcp/config/McpConfig.kt
+++ b/src/main/kotlin/net/portswigger/mcp/config/McpConfig.kt
@@ -28,16 +28,6 @@ class McpConfig(storage: PersistedObject, private val logging: Logging) {
             }
         }
 
-    private var _alwaysAllowHttpArtifacts by storage.boolean(false)
-    var alwaysAllowHttpArtifacts: Boolean
-        get() = _alwaysAllowHttpArtifacts
-        set(value) {
-            if (_alwaysAllowHttpArtifacts != value) {
-                _alwaysAllowHttpArtifacts = value
-                notifyDataAccessChanged()
-            }
-        }
-
     private var _alwaysAllowWebSocketHistory by storage.boolean(false)
     var alwaysAllowWebSocketHistory: Boolean
         get() = _alwaysAllowWebSocketHistory

--- a/src/main/kotlin/net/portswigger/mcp/config/McpConfig.kt
+++ b/src/main/kotlin/net/portswigger/mcp/config/McpConfig.kt
@@ -28,6 +28,16 @@ class McpConfig(storage: PersistedObject, private val logging: Logging) {
             }
         }
 
+    private var _alwaysAllowHttpArtifacts by storage.boolean(false)
+    var alwaysAllowHttpArtifacts: Boolean
+        get() = _alwaysAllowHttpArtifacts
+        set(value) {
+            if (_alwaysAllowHttpArtifacts != value) {
+                _alwaysAllowHttpArtifacts = value
+                notifyDataAccessChanged()
+            }
+        }
+
     private var _alwaysAllowWebSocketHistory by storage.boolean(false)
     var alwaysAllowWebSocketHistory: Boolean
         get() = _alwaysAllowWebSocketHistory

--- a/src/main/kotlin/net/portswigger/mcp/config/components/ServerConfigurationPanel.kt
+++ b/src/main/kotlin/net/portswigger/mcp/config/components/ServerConfigurationPanel.kt
@@ -16,6 +16,7 @@ class ServerConfigurationPanel(
 ) : JPanel() {
 
     private lateinit var alwaysAllowHttpHistoryCheckBox: JCheckBox
+    private lateinit var alwaysAllowHttpArtifactsCheckBox: JCheckBox
     private lateinit var alwaysAllowWebSocketHistoryCheckBox: JCheckBox
     private lateinit var alwaysAllowOrganizerCheckBox: JCheckBox
 
@@ -72,6 +73,14 @@ class ServerConfigurationPanel(
         add(alwaysAllowHttpHistoryCheckBox)
         add(createVerticalStrut(Design.Spacing.SM))
 
+        alwaysAllowHttpArtifactsCheckBox = createIndentedCheckBox(
+            "Always allow site map, Repeater, and MCP HTTP artifact access",
+            config.alwaysAllowHttpArtifacts,
+            config.requireDataAccessApproval
+        ) { config.alwaysAllowHttpArtifacts = it }
+        add(alwaysAllowHttpArtifactsCheckBox)
+        add(createVerticalStrut(Design.Spacing.SM))
+
         alwaysAllowWebSocketHistoryCheckBox = createIndentedCheckBox(
             "Always allow WebSocket history access",
             config.alwaysAllowWebSocketHistory,
@@ -119,13 +128,16 @@ class ServerConfigurationPanel(
             config.requireDataAccessApproval = enabled
             if (!enabled) {
                 config.alwaysAllowHttpHistory = false
+                config.alwaysAllowHttpArtifacts = false
                 config.alwaysAllowWebSocketHistory = false
                 config.alwaysAllowOrganizer = false
                 alwaysAllowHttpHistoryCheckBox.isSelected = false
+                alwaysAllowHttpArtifactsCheckBox.isSelected = false
                 alwaysAllowWebSocketHistoryCheckBox.isSelected = false
                 alwaysAllowOrganizerCheckBox.isSelected = false
             }
             alwaysAllowHttpHistoryCheckBox.isEnabled = enabled
+            alwaysAllowHttpArtifactsCheckBox.isEnabled = enabled
             alwaysAllowWebSocketHistoryCheckBox.isEnabled = enabled
             alwaysAllowOrganizerCheckBox.isEnabled = enabled
         }
@@ -134,6 +146,7 @@ class ServerConfigurationPanel(
     fun updateDataAccessCheckboxes() {
         SwingUtilities.invokeLater {
             alwaysAllowHttpHistoryCheckBox.isSelected = config.alwaysAllowHttpHistory
+            alwaysAllowHttpArtifactsCheckBox.isSelected = config.alwaysAllowHttpArtifacts
             alwaysAllowWebSocketHistoryCheckBox.isSelected = config.alwaysAllowWebSocketHistory
             alwaysAllowOrganizerCheckBox.isSelected = config.alwaysAllowOrganizer
         }

--- a/src/main/kotlin/net/portswigger/mcp/config/components/ServerConfigurationPanel.kt
+++ b/src/main/kotlin/net/portswigger/mcp/config/components/ServerConfigurationPanel.kt
@@ -16,7 +16,6 @@ class ServerConfigurationPanel(
 ) : JPanel() {
 
     private lateinit var alwaysAllowHttpHistoryCheckBox: JCheckBox
-    private lateinit var alwaysAllowHttpArtifactsCheckBox: JCheckBox
     private lateinit var alwaysAllowWebSocketHistoryCheckBox: JCheckBox
     private lateinit var alwaysAllowOrganizerCheckBox: JCheckBox
 
@@ -68,17 +67,9 @@ class ServerConfigurationPanel(
         add(createVerticalStrut(Design.Spacing.SM))
 
         alwaysAllowHttpHistoryCheckBox = createIndentedCheckBox(
-            "Always allow HTTP history access", config.alwaysAllowHttpHistory, config.requireDataAccessApproval
+            "Always allow HTTP message access", config.alwaysAllowHttpHistory, config.requireDataAccessApproval
         ) { config.alwaysAllowHttpHistory = it }
         add(alwaysAllowHttpHistoryCheckBox)
-        add(createVerticalStrut(Design.Spacing.SM))
-
-        alwaysAllowHttpArtifactsCheckBox = createIndentedCheckBox(
-            "Always allow site map, Repeater, and MCP HTTP artifact access",
-            config.alwaysAllowHttpArtifacts,
-            config.requireDataAccessApproval
-        ) { config.alwaysAllowHttpArtifacts = it }
-        add(alwaysAllowHttpArtifactsCheckBox)
         add(createVerticalStrut(Design.Spacing.SM))
 
         alwaysAllowWebSocketHistoryCheckBox = createIndentedCheckBox(
@@ -128,16 +119,13 @@ class ServerConfigurationPanel(
             config.requireDataAccessApproval = enabled
             if (!enabled) {
                 config.alwaysAllowHttpHistory = false
-                config.alwaysAllowHttpArtifacts = false
                 config.alwaysAllowWebSocketHistory = false
                 config.alwaysAllowOrganizer = false
                 alwaysAllowHttpHistoryCheckBox.isSelected = false
-                alwaysAllowHttpArtifactsCheckBox.isSelected = false
                 alwaysAllowWebSocketHistoryCheckBox.isSelected = false
                 alwaysAllowOrganizerCheckBox.isSelected = false
             }
             alwaysAllowHttpHistoryCheckBox.isEnabled = enabled
-            alwaysAllowHttpArtifactsCheckBox.isEnabled = enabled
             alwaysAllowWebSocketHistoryCheckBox.isEnabled = enabled
             alwaysAllowOrganizerCheckBox.isEnabled = enabled
         }
@@ -146,7 +134,6 @@ class ServerConfigurationPanel(
     fun updateDataAccessCheckboxes() {
         SwingUtilities.invokeLater {
             alwaysAllowHttpHistoryCheckBox.isSelected = config.alwaysAllowHttpHistory
-            alwaysAllowHttpArtifactsCheckBox.isSelected = config.alwaysAllowHttpArtifacts
             alwaysAllowWebSocketHistoryCheckBox.isSelected = config.alwaysAllowWebSocketHistory
             alwaysAllowOrganizerCheckBox.isSelected = config.alwaysAllowOrganizer
         }

--- a/src/main/kotlin/net/portswigger/mcp/security/DataAccessSecurity.kt
+++ b/src/main/kotlin/net/portswigger/mcp/security/DataAccessSecurity.kt
@@ -7,7 +7,7 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 enum class DataAccessType() {
-    HTTP_HISTORY(), WEBSOCKET_HISTORY(), ORGANIZER();
+    HTTP_HISTORY(), HTTP_ARTIFACTS(), WEBSOCKET_HISTORY(), ORGANIZER();
 }
 
 interface DataAccessApprovalHandler {
@@ -22,6 +22,7 @@ class SwingDataAccessApprovalHandler : DataAccessApprovalHandler {
             SwingUtilities.invokeLater {
                 val accessTypeName = when (accessType) {
                     DataAccessType.HTTP_HISTORY -> "HTTP history"
+                    DataAccessType.HTTP_ARTIFACTS -> "site map, Repeater, and MCP HTTP artifacts"
                     DataAccessType.WEBSOCKET_HISTORY -> "WebSocket history"
                     DataAccessType.ORGANIZER -> "Organizer items"
                 }
@@ -51,6 +52,7 @@ class SwingDataAccessApprovalHandler : DataAccessApprovalHandler {
                     1 -> {
                         when (accessType) {
                             DataAccessType.HTTP_HISTORY -> config.alwaysAllowHttpHistory = true
+                            DataAccessType.HTTP_ARTIFACTS -> config.alwaysAllowHttpArtifacts = true
                             DataAccessType.WEBSOCKET_HISTORY -> config.alwaysAllowWebSocketHistory = true
                             DataAccessType.ORGANIZER -> config.alwaysAllowOrganizer = true
                         }
@@ -79,6 +81,7 @@ object DataAccessSecurity {
 
         val isAlwaysAllowed = when (accessType) {
             DataAccessType.HTTP_HISTORY -> config.alwaysAllowHttpHistory
+            DataAccessType.HTTP_ARTIFACTS -> config.alwaysAllowHttpArtifacts
             DataAccessType.WEBSOCKET_HISTORY -> config.alwaysAllowWebSocketHistory
             DataAccessType.ORGANIZER -> config.alwaysAllowOrganizer
         }

--- a/src/main/kotlin/net/portswigger/mcp/security/DataAccessSecurity.kt
+++ b/src/main/kotlin/net/portswigger/mcp/security/DataAccessSecurity.kt
@@ -7,7 +7,7 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 enum class DataAccessType() {
-    HTTP_HISTORY(), HTTP_ARTIFACTS(), WEBSOCKET_HISTORY(), ORGANIZER();
+    HTTP_HISTORY(), WEBSOCKET_HISTORY(), ORGANIZER();
 }
 
 interface DataAccessApprovalHandler {
@@ -21,8 +21,7 @@ class SwingDataAccessApprovalHandler : DataAccessApprovalHandler {
         return suspendCoroutine { continuation ->
             SwingUtilities.invokeLater {
                 val accessTypeName = when (accessType) {
-                    DataAccessType.HTTP_HISTORY -> "HTTP history"
-                    DataAccessType.HTTP_ARTIFACTS -> "site map, Repeater, and MCP HTTP artifacts"
+                    DataAccessType.HTTP_HISTORY -> "HTTP messages"
                     DataAccessType.WEBSOCKET_HISTORY -> "WebSocket history"
                     DataAccessType.ORGANIZER -> "Organizer items"
                 }
@@ -52,7 +51,6 @@ class SwingDataAccessApprovalHandler : DataAccessApprovalHandler {
                     1 -> {
                         when (accessType) {
                             DataAccessType.HTTP_HISTORY -> config.alwaysAllowHttpHistory = true
-                            DataAccessType.HTTP_ARTIFACTS -> config.alwaysAllowHttpArtifacts = true
                             DataAccessType.WEBSOCKET_HISTORY -> config.alwaysAllowWebSocketHistory = true
                             DataAccessType.ORGANIZER -> config.alwaysAllowOrganizer = true
                         }
@@ -81,7 +79,6 @@ object DataAccessSecurity {
 
         val isAlwaysAllowed = when (accessType) {
             DataAccessType.HTTP_HISTORY -> config.alwaysAllowHttpHistory
-            DataAccessType.HTTP_ARTIFACTS -> config.alwaysAllowHttpArtifacts
             DataAccessType.WEBSOCKET_HISTORY -> config.alwaysAllowWebSocketHistory
             DataAccessType.ORGANIZER -> config.alwaysAllowOrganizer
         }

--- a/src/main/kotlin/net/portswigger/mcp/tools/HttpMessageTools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/HttpMessageTools.kt
@@ -176,9 +176,8 @@ internal fun Server.registerHttpMessageTools(api: MontoyaApi, config: McpConfig,
 private fun requireSourceAccess(api: MontoyaApi, config: McpConfig, sources: Set<String>) {
     sources.mapTo(mutableSetOf()) {
         when (it) {
-            "proxy" -> DataAccessType.HTTP_HISTORY
             "organizer" -> DataAccessType.ORGANIZER
-            else -> DataAccessType.HTTP_ARTIFACTS
+            else -> DataAccessType.HTTP_HISTORY
         }
     }
         .forEach { accessType ->

--- a/src/main/kotlin/net/portswigger/mcp/tools/HttpMessageTools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/HttpMessageTools.kt
@@ -1,0 +1,389 @@
+package net.portswigger.mcp.tools
+
+import burp.api.montoya.MontoyaApi
+import burp.api.montoya.core.Annotations
+import burp.api.montoya.core.Registration
+import burp.api.montoya.core.ToolType
+import burp.api.montoya.http.handler.HttpHandler
+import burp.api.montoya.http.handler.HttpRequestToBeSent
+import burp.api.montoya.http.handler.HttpResponseReceived
+import burp.api.montoya.http.handler.RequestToBeSentAction
+import burp.api.montoya.http.handler.ResponseReceivedAction
+import burp.api.montoya.http.message.HttpHeader
+import burp.api.montoya.http.message.HttpMessage
+import burp.api.montoya.http.message.HttpRequestResponse
+import burp.api.montoya.http.message.requests.HttpRequest
+import burp.api.montoya.http.message.responses.HttpResponse
+import burp.api.montoya.organizer.OrganizerItem
+import burp.api.montoya.proxy.ProxyHttpRequestResponse
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
+import net.portswigger.mcp.config.McpConfig
+import net.portswigger.mcp.security.DataAccessSecurity
+import net.portswigger.mcp.security.DataAccessType
+import java.security.MessageDigest
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicLong
+import java.util.regex.Pattern
+import java.util.regex.PatternSyntaxException
+
+private const val MAX_SEARCH_RESULTS = 100
+private const val MAX_BODY_WINDOW = 65_536
+private const val MAX_ARTIFACTS = 1_000
+private val HTTP_PARTS = setOf("request_line", "request_headers", "request_body", "response_headers", "response_body")
+private val HTTP_SOURCES = setOf("proxy", "organizer", "site_map", "repeater", "mcp_send")
+
+@Serializable
+data class SearchHttpMessages(
+    val sources: List<String> = HTTP_SOURCES.toList(),
+    val method: String? = null,
+    val host: String? = null,
+    val urlRegex: String? = null,
+    val status: Int? = null,
+    val mimeType: String? = null,
+    val newestFirst: Boolean = true,
+    val count: Int = 20,
+    val offset: Int = 0
+) {
+    init {
+        require(sources.isNotEmpty()) { "sources must not be empty" }
+        require(sources.all { it in HTTP_SOURCES }) { "sources must contain only ${HTTP_SOURCES.joinToString()}" }
+        require(count in 1..MAX_SEARCH_RESULTS) { "count must be between 1 and $MAX_SEARCH_RESULTS" }
+        require(offset >= 0) { "offset must be 0 or greater" }
+        require(status == null || status in 100..999) { "status must be between 100 and 999" }
+        urlRegex?.let(::compileRegex)
+    }
+}
+
+@Serializable
+data class InspectHttpMessage(
+    val handle: String,
+    val parts: List<String>,
+    val bodyOffset: Int = 0,
+    val bodyLength: Int = 4_096
+) {
+    init {
+        require(handle.isNotBlank()) { "handle must not be blank" }
+        require(parts.isNotEmpty()) { "parts must not be empty" }
+        require(parts.all { it in HTTP_PARTS }) { "parts must contain only ${HTTP_PARTS.joinToString()}" }
+        require(bodyOffset >= 0) { "bodyOffset must be 0 or greater" }
+        require(bodyLength in 0..MAX_BODY_WINDOW) { "bodyLength must be between 0 and $MAX_BODY_WINDOW" }
+    }
+}
+
+@Serializable
+data class SearchHttpMessagesResult(val items: List<HttpMessageSummary>, val nextOffset: Int?)
+
+@Serializable
+data class HttpMessageSummary(
+    val handle: String,
+    val source: String,
+    val sourceId: String,
+    val requestFingerprint: String,
+    val responseFingerprint: String?,
+    val sourceLive: Boolean,
+    val snapshotAvailable: Boolean,
+    val method: String,
+    val url: String,
+    val urlTruncated: Boolean,
+    val service: HttpServiceSummary,
+    val status: Int?,
+    val mimeType: String,
+    val requestSize: Int,
+    val responseSize: Int?,
+    val capturedAt: String,
+    val sourceTimestamp: String?,
+    val notes: String,
+    val annotationsTruncated: Boolean,
+    val highlightColor: String?
+)
+
+@Serializable
+data class HttpServiceSummary(val host: String, val port: Int, val secure: Boolean)
+
+@Serializable
+data class InspectHttpMessageResult(
+    val handle: String,
+    val source: String,
+    val sourceLive: Boolean,
+    val snapshotAvailable: Boolean,
+    val requestFingerprint: String,
+    val responseFingerprint: String?,
+    val parts: List<InspectedHttpPart>
+)
+
+@Serializable
+data class InspectedHttpPart(
+    val name: String,
+    val available: Boolean,
+    val content: String?,
+    val originalSize: Int,
+    val rangeStart: Int,
+    val rangeEndExclusive: Int,
+    val hasMore: Boolean,
+    val truncated: Boolean,
+    val redacted: Boolean
+)
+
+internal fun Server.registerHttpMessageTools(api: MontoyaApi, config: McpConfig, artifacts: HttpArtifactRegistry) {
+    mcpStructuredTool<SearchHttpMessages, SearchHttpMessagesResult>(
+        "Search compact metadata for HTTP artifacts from Proxy, Organizer, site map, Repeater, or MCP sends. " +
+            "Returns stable extension-owned handles, never headers or bodies. Evicted artifacts can be recovered by searching live sources again."
+    ) {
+        val requestedSources = sources.distinct().toSet()
+        requireSourceAccess(api, config, requestedSources)
+        artifacts.refresh(requestedSources)
+        val urlPattern = urlRegex?.let(Pattern::compile)
+        val matching = artifacts.all().asSequence().filter { artifact ->
+            artifact.source in requestedSources &&
+                (method == null || artifact.method.equals(method, ignoreCase = true)) &&
+                (host == null || artifact.service.host.equals(host, ignoreCase = true)) &&
+                (urlPattern == null || urlPattern.matcher(artifact.url).find()) &&
+                (status == null || artifact.status == status) &&
+                (mimeType == null || artifact.mimeType.equals(mimeType, ignoreCase = true))
+        }
+        val ordered = if (newestFirst) matching.sortedByDescending { it.capturedAt }.asSequence() else matching
+        val page = ordered.drop(offset).take(count + 1).toList()
+        SearchHttpMessagesResult(page.take(count).map(HttpArtifact::summary), if (page.size > count) offset + count else null)
+    }
+
+    mcpStructuredTool<InspectHttpMessage, InspectHttpMessageResult>(
+        "Inspect selected request or response parts for a handle returned by search_http_messages. " +
+            "Body windows are byte ranges; unknown or evicted handles require another search."
+    ) {
+        val artifact = artifacts.resolve(handle)
+        requireSourceAccess(api, config, setOf(artifact.source))
+        InspectHttpMessageResult(
+            handle, artifact.source, artifact.sourceLive, artifact.snapshotAvailable,
+            artifact.requestFingerprint, artifact.responseFingerprint,
+            parts.distinct().map { part ->
+                when (part) {
+                    "request_line" -> textPart(part, "${artifact.request.method()} ${artifact.request.path()} ${artifact.request.httpVersion()}")
+                    "request_headers" -> textPart(part, artifact.request.headers().asText())
+                    "request_body" -> bodyPart(part, artifact.request, bodyOffset, bodyLength)
+                    "response_headers" -> artifact.response?.let { response ->
+                        textPart(part, "${response.httpVersion()} ${response.statusCode()} ${response.reasonPhrase()}\r\n${response.headers().asText()}")
+                    } ?: unavailablePart(part)
+                    "response_body" -> artifact.response?.let { bodyPart(part, it, bodyOffset, bodyLength) } ?: unavailablePart(part)
+                    else -> error("validated part was not handled")
+                }
+            }
+        )
+    }
+}
+
+private fun requireSourceAccess(api: MontoyaApi, config: McpConfig, sources: Set<String>) {
+    sources.mapTo(mutableSetOf()) {
+        when (it) {
+            "proxy" -> DataAccessType.HTTP_HISTORY
+            "organizer" -> DataAccessType.ORGANIZER
+            else -> DataAccessType.HTTP_ARTIFACTS
+        }
+    }
+        .forEach { accessType ->
+            val allowed = runBlocking { DataAccessSecurity.checkDataAccessPermission(accessType, config) }
+            api.logging().logToOutput("MCP ${accessType.name.lowercase()} access ${if (allowed) "granted" else "denied"}")
+            if (!allowed) mcpError("HTTP artifact access was denied in Burp Suite. Allow project data access and retry.")
+        }
+}
+
+internal class HttpArtifactRegistry(
+    private val api: MontoyaApi,
+    private val maxArtifacts: Int = MAX_ARTIFACTS,
+    private val now: () -> Instant = Instant::now
+) : AutoCloseable {
+    private val byIdentity = LinkedHashMap<String, HttpArtifact>(16, 0.75f, true)
+    private val byHandle = mutableMapOf<String, HttpArtifact>()
+    private val sendSequence = AtomicLong()
+    private var handlerRegistration: Registration? = null
+
+    @Synchronized
+    fun start() {
+        if (handlerRegistration != null) return
+        handlerRegistration = api.http().registerHttpHandler(object : HttpHandler {
+            override fun handleHttpRequestToBeSent(requestToBeSent: HttpRequestToBeSent) =
+                RequestToBeSentAction.continueWith(requestToBeSent)
+
+            override fun handleHttpResponseReceived(responseReceived: HttpResponseReceived): ResponseReceivedAction {
+                if (responseReceived.toolSource().isFromTool(ToolType.REPEATER)) {
+                    capture(
+                        "repeater", "${responseReceived.messageId()}:${responseReceived.initiatingRequest().fingerprint()}",
+                        responseReceived.initiatingRequest(), responseReceived, responseReceived.annotations(), sourceLive = false
+                    )
+                }
+                return ResponseReceivedAction.continueWith(responseReceived)
+            }
+        })
+    }
+
+    fun captureMcpSend(exchange: HttpRequestResponse) {
+        runCatching {
+            val request = exchange.request() ?: return
+            capture(
+                "mcp_send", sendSequence.incrementAndGet().toString(), request, exchange.response(),
+                exchange.annotations(), sourceLive = false
+            )
+        }.onFailure { api.logging().logToError("Could not index MCP HTTP exchange") }
+    }
+
+    @Synchronized
+    fun refresh(sources: Set<String>) {
+        val queryable = sources intersect setOf("proxy", "organizer", "site_map")
+        byIdentity.values.filter { it.source in queryable }.forEach { it.sourceLive = false }
+        if ("proxy" in sources) api.proxy().history().forEach(::captureProxy)
+        if ("organizer" in sources) api.organizer().items().forEach(::captureOrganizer)
+        if ("site_map" in sources) api.siteMap().requestResponses().forEach(::captureSiteMap)
+    }
+
+    @Synchronized
+    fun all(): List<HttpArtifact> = byIdentity.values.toList()
+
+    @Synchronized
+    fun resolve(handle: String): HttpArtifact = byHandle[handle]
+        ?: mcpError("Unknown HTTP artifact handle. It may have been evicted or the extension restarted; run search_http_messages again.")
+
+    override fun close() {
+        handlerRegistration?.deregister()
+        handlerRegistration = null
+    }
+
+    private fun captureProxy(item: ProxyHttpRequestResponse) = capture(
+        "proxy", item.id().toString(), item.finalRequest(), item.response(), item.annotations(),
+        item.time().toInstant(), true, item.mimeType().name
+    )
+
+    private fun captureOrganizer(item: OrganizerItem) {
+        val request = item.request() ?: return
+        capture("organizer", item.id().toString(), request, item.response(), item.annotations(), sourceLive = true)
+    }
+
+    private fun captureSiteMap(item: HttpRequestResponse) {
+        val request = item.request() ?: return
+        val response = item.response()
+        capture(
+            "site_map", "${request.fingerprint()}:${response?.fingerprint() ?: "no_response"}",
+            request, response, item.annotations(), sourceLive = true
+        )
+    }
+
+    @Synchronized
+    private fun capture(
+        source: String,
+        sourceId: String,
+        request: HttpRequest,
+        response: HttpResponse?,
+        annotations: Annotations,
+        sourceTimestamp: Instant? = null,
+        sourceLive: Boolean,
+        mimeType: String? = null
+    ): HttpArtifact {
+        val identity = "$source:$sourceId"
+        val requestFingerprint = request.fingerprint()
+        val responseFingerprint = response?.fingerprint()
+        val notes = annotations.notes().orEmpty().bounded(500)
+        val existing = byIdentity[identity]
+        if (existing != null && existing.requestFingerprint == requestFingerprint && existing.responseFingerprint == responseFingerprint) {
+            existing.sourceLive = sourceLive
+            existing.sourceTimestamp = sourceTimestamp ?: existing.sourceTimestamp
+            existing.notes = notes.value
+            existing.annotationsTruncated = notes.truncated
+            existing.highlightColor = if (annotations.hasHighlightColor()) annotations.highlightColor().name else null
+            return existing
+        }
+
+        val requestSnapshot = runCatching { request.copyToTempFile() }.getOrNull()
+        val responseSnapshot = response?.let { runCatching { it.copyToTempFile() }.getOrNull() }
+        val service = request.httpService()
+        val url = request.url().bounded(2_048)
+        val artifact = HttpArtifact(
+            existing?.handle ?: identity.stableHandle(),
+            source, sourceId, requestSnapshot ?: request, responseSnapshot ?: response, requestFingerprint, responseFingerprint,
+            sourceLive, requestSnapshot != null && (response == null || responseSnapshot != null),
+            request.method().bounded(32).value, url.value, url.truncated,
+            HttpServiceSummary(service.host().bounded(253).value, service.port(), service.secure()),
+            response?.statusCode()?.toInt(), mimeType ?: response?.mimeType()?.name ?: request.contentType().name,
+            request.toByteArray().length(), response?.toByteArray()?.length(), existing?.capturedAt ?: now(), sourceTimestamp,
+            notes.value, notes.truncated, if (annotations.hasHighlightColor()) annotations.highlightColor().name else null
+        )
+        existing?.let { byHandle.remove(it.handle) }
+        byIdentity[identity] = artifact
+        byHandle[artifact.handle] = artifact
+        while (byIdentity.size > maxArtifacts) {
+            val evicted = byIdentity.entries.first()
+            byIdentity.remove(evicted.key)
+            byHandle.remove(evicted.value.handle)
+        }
+        return artifact
+    }
+}
+
+internal data class HttpArtifact(
+    val handle: String,
+    val source: String,
+    val sourceId: String,
+    val request: HttpRequest,
+    val response: HttpResponse?,
+    val requestFingerprint: String,
+    val responseFingerprint: String?,
+    var sourceLive: Boolean,
+    val snapshotAvailable: Boolean,
+    val method: String,
+    val url: String,
+    val urlTruncated: Boolean,
+    val service: HttpServiceSummary,
+    val status: Int?,
+    val mimeType: String,
+    val requestSize: Int,
+    val responseSize: Int?,
+    val capturedAt: Instant,
+    var sourceTimestamp: Instant?,
+    var notes: String,
+    var annotationsTruncated: Boolean,
+    var highlightColor: String?
+) {
+    fun summary() = HttpMessageSummary(
+        handle, source, sourceId, requestFingerprint, responseFingerprint, sourceLive, snapshotAvailable,
+        method, url, urlTruncated, service, status, mimeType, requestSize, responseSize,
+        capturedAt.toString(), sourceTimestamp?.toString(), notes, annotationsTruncated, highlightColor
+    )
+}
+
+private fun HttpMessage.fingerprint(): String = MessageDigest.getInstance("SHA-256")
+    .digest(toByteArray().bytes)
+    .joinToString("") { "%02x".format(it) }
+
+private fun String.stableHandle(): String = "http_" + MessageDigest.getInstance("SHA-256")
+    .digest(toByteArray())
+    .take(16)
+    .joinToString("") { "%02x".format(it) }
+
+private fun List<HttpHeader>.asText() = joinToString("\r\n") { "${it.name()}: ${it.value()}" }
+
+private fun textPart(name: String, content: String): InspectedHttpPart {
+    val size = content.toByteArray().size
+    return InspectedHttpPart(name, true, content, size, 0, size, false, false, false)
+}
+
+private fun bodyPart(name: String, message: HttpMessage, offset: Int, length: Int): InspectedHttpPart {
+    val body = message.body()
+    val start = offset.coerceAtMost(body.length())
+    val end = (start.toLong() + length).coerceAtMost(body.length().toLong()).toInt()
+    return InspectedHttpPart(
+        name, true, body.subArray(start, end).toString(), body.length(), start, end,
+        hasMore = end < body.length(), truncated = start > 0 || end < body.length(), redacted = false
+    )
+}
+
+private fun unavailablePart(name: String) = InspectedHttpPart(name, false, null, 0, 0, 0, false, false, false)
+
+private data class BoundedText(val value: String, val truncated: Boolean)
+private fun String.bounded(maxLength: Int) = BoundedText(take(maxLength), length > maxLength)
+
+private fun compileRegex(regex: String) {
+    try {
+        Pattern.compile(regex)
+    } catch (error: PatternSyntaxException) {
+        throw IllegalArgumentException("urlRegex is invalid at index ${error.index}: ${error.description}")
+    }
+}

--- a/src/main/kotlin/net/portswigger/mcp/tools/McpTool.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/McpTool.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.serializer
 import net.portswigger.mcp.schema.asInputSchema
 import kotlin.experimental.ExperimentalTypeInference
@@ -93,6 +94,41 @@ inline fun <reified I : Any> Server.mcpTool(
     }
 
     addTool(name = toolName, description = description, inputSchema = inputSchema, handler = handler)
+}
+
+@OptIn(InternalSerializationApi::class)
+inline fun <reified I : Any, reified O : Any> Server.mcpStructuredTool(
+    description: String,
+    crossinline execute: I.() -> O
+) {
+    val toolName = I::class.simpleName?.toLowerSnakeCase() ?: error("Couldn't find name for ${I::class}")
+    val inputSerializer = I::class.serializer()
+    val outputSerializer = O::class.serializer()
+    val handler: suspend (ClientConnection, CallToolRequest) -> CallToolResult = { _, request ->
+        try {
+            val input = ToolJson.decodeFromJsonElement(
+                inputSerializer,
+                coerceWholeNumberArguments(request.params.arguments ?: JsonObject(emptyMap()), I::class)
+            )
+            val output = execute(input)
+            val structured = ToolJson.encodeToJsonElement(outputSerializer, output).jsonObject
+            CallToolResult(
+                content = listOf(TextContent(ToolJson.encodeToString(outputSerializer, output))),
+                structuredContent = structured,
+                isError = false
+            )
+        } catch (e: Exception) {
+            toolErrorResult(toolName, e)
+        }
+    }
+
+    addTool(
+        name = toolName,
+        description = description,
+        inputSchema = I::class.asInputSchema(),
+        outputSchema = O::class.asInputSchema(),
+        handler = handler
+    )
 }
 
 @OptIn(ExperimentalTypeInference::class)

--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -109,7 +109,9 @@ private fun normalizePrelude(prelude: String): String = prelude
     .replace("\r", "")          // Actual CR → remove
     .replace("\n", "\r\n")      // All LF → proper CRLF
 
-fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
+internal fun Server.registerTools(api: MontoyaApi, config: McpConfig, httpArtifacts: HttpArtifactRegistry) {
+
+    registerHttpMessageTools(api, config, httpArtifacts)
 
     mcpTool<SendHttp1Request>("Issues an HTTP/1.1 request and returns the response.") {
         val allowed = runBlocking {
@@ -126,6 +128,8 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
 
         val request = HttpRequest.httpRequest(toMontoyaService(), fixedContent)
         val response = api.http().sendRequest(request)
+
+        response?.let(httpArtifacts::captureMcpSend)
 
         response?.toString() ?: mcpError("No HTTP response was received from $targetHostname:$targetPort. Check the target and Burp network settings.")
     }
@@ -159,6 +163,8 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
 
         val request = HttpRequest.http2Request(toMontoyaService(), headerList, requestBody)
         val response = api.http().sendRequest(request, HttpMode.HTTP_2)
+
+        response?.let(httpArtifacts::captureMcpSend)
 
         response?.toString() ?: mcpError("No HTTP response was received from $targetHostname:$targetPort. Check the target and Burp network settings.")
     }

--- a/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
@@ -70,7 +70,6 @@ class ToolsKtTest {
             every { getBoolean("requireHttpRequestApproval") } returns false
             every { getBoolean("requireDataAccessApproval") } returns false
             every { getBoolean("_alwaysAllowHttpHistory") } returns false
-            every { getBoolean("_alwaysAllowHttpArtifacts") } returns false
             every { getBoolean("_alwaysAllowWebSocketHistory") } returns false
             every { getBoolean("_alwaysAllowOrganizer") } returns false
             every { getString("host") } returns "127.0.0.1"

--- a/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
@@ -5,12 +5,19 @@ import burp.api.montoya.burpsuite.TaskExecutionEngine
 import burp.api.montoya.collaborator.*
 import burp.api.montoya.core.BurpSuiteEdition
 import burp.api.montoya.core.ByteArray
+import burp.api.montoya.core.ToolType as BurpToolType
 import burp.api.montoya.http.Http
 import burp.api.montoya.http.HttpMode
 import burp.api.montoya.http.HttpProtocol
+import burp.api.montoya.http.handler.HttpHandler
+import burp.api.montoya.http.handler.HttpResponseReceived
+import burp.api.montoya.http.handler.ResponseReceivedAction
 import burp.api.montoya.http.message.HttpHeader
+import burp.api.montoya.http.message.MimeType
 import burp.api.montoya.http.message.requests.HttpRequest
+import burp.api.montoya.http.message.responses.HttpResponse
 import burp.api.montoya.logging.Logging
+import burp.api.montoya.organizer.OrganizerItem
 import burp.api.montoya.persistence.PersistedObject
 import burp.api.montoya.proxy.Proxy
 import burp.api.montoya.proxy.ProxyHttpRequestResponse
@@ -63,6 +70,7 @@ class ToolsKtTest {
             every { getBoolean("requireHttpRequestApproval") } returns false
             every { getBoolean("requireDataAccessApproval") } returns false
             every { getBoolean("_alwaysAllowHttpHistory") } returns false
+            every { getBoolean("_alwaysAllowHttpArtifacts") } returns false
             every { getBoolean("_alwaysAllowWebSocketHistory") } returns false
             every { getBoolean("_alwaysAllowOrganizer") } returns false
             every { getString("host") } returns "127.0.0.1"
@@ -131,6 +139,18 @@ class ToolsKtTest {
             }
         }
     }
+
+    private fun mockBytes(content: String): ByteArray {
+        val bytes = content.toByteArray()
+        return mockk<ByteArray>().also { result ->
+            every { result.length() } returns bytes.size
+            every { result.bytes } returns bytes
+            every { result.subArray(any(), any()) } answers {
+                mockBytes(bytes.copyOfRange(firstArg(), secondArg()).toString(Charsets.UTF_8))
+            }
+            every { result.toString() } returns content
+        }
+    }
     
     @BeforeEach
     fun setup() {
@@ -167,6 +187,7 @@ class ToolsKtTest {
         "requestBody", "text" -> ""
         "json" -> "{}"
         "regex" -> ".*"
+        "parts" -> listOf("response_headers")
         "count", "length" -> 1.0
         "offset" -> 0.0
         "characterSet" -> "a"
@@ -879,6 +900,355 @@ class ToolsKtTest {
     
     @Nested
     inner class PaginatedToolsTests {
+        @Test
+        fun `MCP sends become searchable snapshot artifacts without changing send output`() {
+            val http = mockk<Http>()
+            val exchange = mockk<burp.api.montoya.http.message.HttpRequestResponse>()
+            val request = mockk<HttpRequest>()
+            val response = mockk<HttpResponse>()
+            val snapshotRequest = mockk<HttpRequest>()
+            val snapshotResponse = mockk<HttpResponse>()
+            val service = mockk<burp.api.montoya.http.HttpService>()
+            val annotations = mockk<burp.api.montoya.core.Annotations>()
+
+            every { api.http() } returns http
+            every { HttpRequest.httpRequest(any(), any<String>()) } returns request
+            every { http.sendRequest(request) } returns exchange
+            every { exchange.toString() } returns "HTTP/1.1 202 Accepted\r\n\r\nqueued"
+            every { exchange.request() } returns request
+            every { exchange.response() } returns response
+            every { exchange.annotations() } returns annotations
+            every { annotations.notes() } returns ""
+            every { annotations.hasHighlightColor() } returns false
+            every { service.host() } returns "example.com"
+            every { service.port() } returns 443
+            every { service.secure() } returns true
+            every { request.method() } returns "POST"
+            every { request.url() } returns "https://example.com/sent"
+            every { request.path() } returns "/sent"
+            every { request.httpVersion() } returns "HTTP/1.1"
+            every { request.httpService() } returns service
+            every { request.toByteArray() } returns mockBytes("POST /sent HTTP/1.1\r\n\r\n")
+            every { request.copyToTempFile() } returns snapshotRequest
+            every { response.statusCode() } returns 202
+            every { response.mimeType() } returns MimeType.PLAIN_TEXT
+            every { response.toByteArray() } returns mockBytes("HTTP/1.1 202 Accepted\r\n\r\nqueued")
+            every { response.copyToTempFile() } returns snapshotResponse
+            every { snapshotResponse.body() } returns mockBytes("saved MCP response")
+
+            runBlocking {
+                val sent = client.callTool(
+                    "send_http1_request", mapOf(
+                        "content" to "POST /sent HTTP/1.1\r\n\r\n",
+                        "targetHostname" to "example.com",
+                        "targetPort" to 443,
+                        "usesHttps" to true
+                    )
+                )
+                assertEquals("HTTP/1.1 202 Accepted\r\n\r\nqueued", sent.expectTextContent())
+
+                val item = Json.parseToJsonElement(
+                    client.callTool(
+                        "search_http_messages",
+                        mapOf("sources" to Json.encodeToJsonElement(listOf("mcp_send")))
+                    ).expectTextContent()
+                ).jsonObject.getValue("items").jsonArray.single().jsonObject
+
+                assertEquals("mcp_send", item.getValue("source").jsonPrimitive.content)
+                assertFalse(item.getValue("sourceLive").jsonPrimitive.content.toBoolean())
+                assertTrue(item.getValue("snapshotAvailable").jsonPrimitive.content.toBoolean())
+                assertEquals(202, item.getValue("status").jsonPrimitive.content.toInt())
+                val inspected = Json.parseToJsonElement(
+                    client.callTool(
+                        "inspect_http_message",
+                        mapOf(
+                            "handle" to item.getValue("handle").jsonPrimitive.content,
+                            "parts" to Json.encodeToJsonElement(listOf("response_body"))
+                        )
+                    ).expectTextContent()
+                ).jsonObject
+                assertEquals(
+                    "saved MCP response",
+                    inspected.getValue("parts").jsonArray.single().jsonObject.getValue("content").jsonPrimitive.content
+                )
+            }
+        }
+
+        @Test
+        fun `repeater results captured by the HTTP handler become snapshot artifacts`() {
+            val handler = slot<HttpHandler>()
+            val received = mockk<HttpResponseReceived>()
+            val nonRepeater = mockk<HttpResponseReceived>()
+            val request = mockk<HttpRequest>()
+            val snapshotRequest = mockk<HttpRequest>()
+            val snapshotResponse = mockk<HttpResponse>()
+            val service = mockk<burp.api.montoya.http.HttpService>()
+            val annotations = mockk<burp.api.montoya.core.Annotations>()
+            val action = mockk<ResponseReceivedAction>()
+
+            verify { api.http().registerHttpHandler(capture(handler)) }
+            mockkStatic(ResponseReceivedAction::class)
+            every { ResponseReceivedAction.continueWith(received) } returns action
+            every { ResponseReceivedAction.continueWith(nonRepeater) } returns action
+            every { nonRepeater.toolSource().isFromTool(BurpToolType.REPEATER) } returns false
+            every { received.toolSource().isFromTool(BurpToolType.REPEATER) } returns true
+            every { received.messageId() } returns 91
+            every { received.initiatingRequest() } returns request
+            every { received.annotations() } returns annotations
+            every { received.statusCode() } returns 201
+            every { received.mimeType() } returns MimeType.JSON
+            every { received.toByteArray() } returns mockBytes("HTTP/1.1 201 Created\r\n\r\n{}")
+            every { received.copyToTempFile() } returns snapshotResponse
+            every { annotations.notes() } returns "from repeater"
+            every { annotations.hasHighlightColor() } returns false
+            every { service.host() } returns "example.com"
+            every { service.port() } returns 443
+            every { service.secure() } returns true
+            every { request.method() } returns "POST"
+            every { request.url() } returns "https://example.com/repeated"
+            every { request.path() } returns "/repeated"
+            every { request.httpVersion() } returns "HTTP/1.1"
+            every { request.httpService() } returns service
+            every { request.toByteArray() } returns mockBytes("POST /repeated HTTP/1.1\r\n\r\n")
+            every { request.copyToTempFile() } returns snapshotRequest
+            every { snapshotResponse.body() } returns mockBytes("saved Repeater response")
+
+            assertSame(action, handler.captured.handleHttpResponseReceived(received))
+            assertSame(action, handler.captured.handleHttpResponseReceived(nonRepeater))
+
+            runBlocking {
+                val item = Json.parseToJsonElement(
+                    client.callTool(
+                        "search_http_messages",
+                        mapOf("sources" to Json.encodeToJsonElement(listOf("repeater")))
+                    ).expectTextContent()
+                ).jsonObject.getValue("items").jsonArray.single().jsonObject
+
+                assertEquals("repeater", item.getValue("source").jsonPrimitive.content)
+                assertFalse(item.getValue("sourceLive").jsonPrimitive.content.toBoolean())
+                assertTrue(item.getValue("snapshotAvailable").jsonPrimitive.content.toBoolean())
+                assertEquals(201, item.getValue("status").jsonPrimitive.content.toInt())
+                val inspected = Json.parseToJsonElement(
+                    client.callTool(
+                        "inspect_http_message",
+                        mapOf(
+                            "handle" to item.getValue("handle").jsonPrimitive.content,
+                            "parts" to Json.encodeToJsonElement(listOf("response_body"))
+                        )
+                    ).expectTextContent()
+                ).jsonObject
+                assertEquals(
+                    "saved Repeater response",
+                    inspected.getValue("parts").jsonArray.single().jsonObject.getValue("content").jsonPrimitive.content
+                )
+            }
+        }
+
+        @Test
+        fun `organizer and site map exchanges become artifacts and retain snapshots after a source disappears`() {
+            val organizerItem = mockk<OrganizerItem>()
+            val siteMapItem = mockk<burp.api.montoya.http.message.HttpRequestResponse>()
+            val organizerRequest = mockk<HttpRequest>()
+            val siteMapRequest = mockk<HttpRequest>()
+            val organizerSnapshot = mockk<HttpRequest>()
+            val siteMapSnapshot = mockk<HttpRequest>()
+            val response = mockk<HttpResponse>()
+            val responseSnapshot = mockk<HttpResponse>()
+            val service = mockk<burp.api.montoya.http.HttpService>()
+            val annotations = mockk<burp.api.montoya.core.Annotations>()
+            val siteMapItems = mutableListOf(siteMapItem)
+
+            every { api.organizer().items() } returns listOf(organizerItem)
+            every { api.siteMap().requestResponses() } answers { siteMapItems.toList() }
+            every { organizerItem.id() } returns 7
+            every { organizerItem.request() } returns organizerRequest
+            every { organizerItem.response() } returns response
+            every { organizerItem.annotations() } returns annotations
+            every { siteMapItem.request() } returns siteMapRequest
+            every { siteMapItem.response() } returns response
+            every { siteMapItem.annotations() } returns annotations
+            every { annotations.notes() } returns ""
+            every { annotations.hasHighlightColor() } returns false
+            every { service.host() } returns "example.com"
+            every { service.port() } returns 443
+            every { service.secure() } returns true
+            listOf(
+                Triple(organizerRequest, organizerSnapshot, "/organized"),
+                Triple(siteMapRequest, siteMapSnapshot, "/mapped")
+            ).forEach { (request, snapshot, path) ->
+                every { request.method() } returns "GET"
+                every { request.url() } returns "https://example.com$path"
+                every { request.path() } returns path
+                every { request.httpVersion() } returns "HTTP/1.1"
+                every { request.httpService() } returns service
+                every { request.toByteArray() } returns mockBytes("GET $path HTTP/1.1\r\n\r\n")
+                every { request.copyToTempFile() } returns snapshot
+            }
+            every { siteMapSnapshot.body() } returns mockBytes("saved site-map request")
+            every { response.statusCode() } returns 200
+            every { response.mimeType() } returns MimeType.JSON
+            every { response.toByteArray() } returns mockBytes("HTTP/1.1 200 OK\r\n\r\n{}")
+            every { response.copyToTempFile() } returns responseSnapshot
+
+            runBlocking {
+                val first = Json.parseToJsonElement(
+                    client.callTool(
+                        "search_http_messages",
+                        mapOf("sources" to Json.encodeToJsonElement(listOf("organizer", "site_map")))
+                    ).expectTextContent()
+                ).jsonObject.getValue("items").jsonArray.map { it.jsonObject }
+
+                assertEquals(setOf("organizer", "site_map"), first.map { it.getValue("source").jsonPrimitive.content }.toSet())
+                val siteMapArtifact = first.single { it.getValue("source").jsonPrimitive.content == "site_map" }
+                val handle = siteMapArtifact.getValue("handle").jsonPrimitive.content
+                assertTrue(siteMapArtifact.getValue("sourceLive").jsonPrimitive.content.toBoolean())
+
+                siteMapItems.clear()
+                val second = Json.parseToJsonElement(
+                    client.callTool(
+                        "search_http_messages",
+                        mapOf("sources" to Json.encodeToJsonElement(listOf("site_map")))
+                    ).expectTextContent()
+                ).jsonObject.getValue("items").jsonArray.single().jsonObject
+
+                assertEquals(handle, second.getValue("handle").jsonPrimitive.content)
+                assertFalse(second.getValue("sourceLive").jsonPrimitive.content.toBoolean())
+                assertTrue(second.getValue("snapshotAvailable").jsonPrimitive.content.toBoolean())
+                val inspected = Json.parseToJsonElement(
+                    client.callTool(
+                        "inspect_http_message",
+                        mapOf(
+                            "handle" to handle,
+                            "parts" to Json.encodeToJsonElement(listOf("request_body"))
+                        )
+                    ).expectTextContent()
+                ).jsonObject
+                assertEquals(
+                    "saved site-map request",
+                    inspected.getValue("parts").jsonArray.single().jsonObject.getValue("content").jsonPrimitive.content
+                )
+            }
+        }
+
+        @Test
+        fun `search metadata handle can inspect a response body window without returning the large request`() {
+            val proxy = mockk<Proxy>()
+            val historyItem = mockk<ProxyHttpRequestResponse>()
+            val request = mockk<HttpRequest>()
+            val response = mockk<HttpResponse>()
+            val service = mockk<burp.api.montoya.http.HttpService>()
+            val requestBytes = mockBytes("GET /large HTTP/1.1\r\nHost: example.com\r\n\r\n${"SECRET_REQUEST_BODY".repeat(1_000)}")
+            val responseBytes = mockBytes("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n0123456789")
+            val responseBody = mockBytes("0123456789")
+            val contentType = mockk<HttpHeader> {
+                every { name() } returns "Content-Type"
+                every { value() } returns "text/plain"
+            }
+
+            every { api.proxy() } returns proxy
+            every { proxy.history() } returns listOf(historyItem)
+            every { historyItem.finalRequest() } returns request
+            every { historyItem.request() } returns request
+            every { historyItem.response() } returns response
+            every { historyItem.httpService() } returns service
+            every { historyItem.id() } returns 42
+            every { historyItem.time() } returns ZonedDateTime.parse("2026-08-13T10:15:30Z")
+            every { historyItem.mimeType() } returns MimeType.PLAIN_TEXT
+            every { historyItem.annotations().notes() } returns "selected"
+            every { historyItem.annotations().hasHighlightColor() } returns false
+            every { service.host() } returns "example.com"
+            every { service.port() } returns 443
+            every { service.secure() } returns true
+            every { request.method() } returns "GET"
+            every { request.url() } returns "https://example.com/large"
+            every { request.httpService() } returns service
+            every { request.path() } returns "/large"
+            every { request.httpVersion() } returns "HTTP/1.1"
+            every { request.headers() } returns listOf(mockk(relaxed = true))
+            every { request.toByteArray() } returns requestBytes
+            every { request.copyToTempFile() } returns request
+            every { response.statusCode() } returns 200
+            every { response.reasonPhrase() } returns "OK"
+            every { response.httpVersion() } returns "HTTP/1.1"
+            every { response.headers() } returns listOf(contentType)
+            every { response.toByteArray() } returns responseBytes
+            every { response.body() } returns responseBody
+            every { response.copyToTempFile() } returns response
+
+            runBlocking {
+                val searchResult = client.callTool(
+                    "search_http_messages", mapOf(
+                        "sources" to Json.encodeToJsonElement(listOf("proxy")),
+                        "host" to "example.com",
+                        "count" to 1
+                    )
+                )
+                val searchText = searchResult.expectTextContent()
+                assertEquals(false, searchResult?.isError, searchText)
+                val search = Json.parseToJsonElement(searchText).jsonObject
+                val item = search.getValue("items").jsonArray.single().jsonObject
+
+                assertEquals(false, searchResult?.isError)
+                assertEquals(search, searchResult?.structuredContent)
+                assertTrue(item.getValue("handle").jsonPrimitive.content.matches(Regex("http_[0-9a-f]{32}")))
+                assertEquals("proxy", item.getValue("source").jsonPrimitive.content)
+                assertEquals("42", item.getValue("sourceId").jsonPrimitive.content)
+                assertEquals("965838a1411422358d8a0986ea6cd3738f5171c42736b46f76996eb93ac70609", item.getValue("requestFingerprint").jsonPrimitive.content)
+                assertEquals("96bd0939ca1f369c143517a01136355453fc10219bfa6cbe38c0f6d33ac88fd8", item.getValue("responseFingerprint").jsonPrimitive.content)
+                assertTrue(item.getValue("sourceLive").jsonPrimitive.content.toBoolean())
+                assertTrue(item.getValue("snapshotAvailable").jsonPrimitive.content.toBoolean())
+                assertEquals("GET", item.getValue("method").jsonPrimitive.content)
+                assertEquals(requestBytes.length(), item.getValue("requestSize").jsonPrimitive.content.toInt())
+                assertFalse(searchText.contains("SECRET_REQUEST_BODY"))
+                assertFalse(searchText.contains("0123456789"))
+
+                val repeated = client.callTool(
+                    "search_http_messages", mapOf("sources" to Json.encodeToJsonElement(listOf("proxy")), "count" to 1)
+                ).expectTextContent()
+                assertEquals(
+                    item.getValue("handle").jsonPrimitive.content,
+                    Json.parseToJsonElement(repeated).jsonObject.getValue("items").jsonArray.single().jsonObject
+                        .getValue("handle").jsonPrimitive.content
+                )
+
+                val inspectResult = client.callTool(
+                    "inspect_http_message", mapOf(
+                        "handle" to item.getValue("handle").jsonPrimitive.content,
+                        "parts" to Json.encodeToJsonElement(listOf("response_headers", "response_body")),
+                        "bodyOffset" to 3,
+                        "bodyLength" to 4
+                    )
+                )
+                val inspected = Json.parseToJsonElement(inspectResult.expectTextContent()).jsonObject
+                val parts = inspected.getValue("parts").jsonArray.map { it.jsonObject }
+                assertEquals(
+                    listOf("response_headers", "response_body"),
+                    parts.map { it.getValue("name").jsonPrimitive.content }
+                )
+                val headers = parts.single { it.getValue("name").jsonPrimitive.content == "response_headers" }
+                val body = parts.single { it.getValue("name").jsonPrimitive.content == "response_body" }
+
+                assertEquals(false, inspectResult?.isError)
+                assertTrue(headers.getValue("content").jsonPrimitive.content.contains("Content-Type: text/plain"))
+                assertEquals("3456", body.getValue("content").jsonPrimitive.content)
+                assertEquals(10, body.getValue("originalSize").jsonPrimitive.content.toInt())
+                assertEquals(3, body.getValue("rangeStart").jsonPrimitive.content.toInt())
+                assertEquals(7, body.getValue("rangeEndExclusive").jsonPrimitive.content.toInt())
+                assertTrue(body.getValue("hasMore").jsonPrimitive.content.toBoolean())
+                assertTrue(body.getValue("truncated").jsonPrimitive.content.toBoolean())
+                assertFalse(body.getValue("redacted").jsonPrimitive.content.toBoolean())
+
+                val unknown = client.callTool(
+                    "inspect_http_message", mapOf(
+                        "handle" to "unknown",
+                        "parts" to Json.encodeToJsonElement(listOf("response_headers"))
+                    )
+                )
+                assertEquals(true, unknown?.isError)
+                assertTrue(unknown.expectTextContent().contains("run search_http_messages again"))
+            }
+        }
+
         @Test
         fun `get proxy history should paginate properly`() {
             val proxy = mockk<Proxy>()


### PR DESCRIPTION
## What changed

- Add stable extension-owned handles for HTTP exchanges from Proxy, Organizer, site map, Repeater results, and MCP sends.
- Keep a bounded in-memory registry with deterministic request/response fingerprints and temp-file-backed snapshots.
- Add compact `search_http_messages` metadata and selective `inspect_http_message` body/header windows.
- Expose source liveness, snapshot availability, service/status/MIME metadata, timestamps, and Burp annotations.
- Apply existing data-access approval controls to the new artifact sources.

## Why

Montoya does not expose durable IDs across all HTTP surfaces. Explicit handles let MCP clients search compact metadata and inspect only the required exchange parts without returning entire messages or relying on protocol-session state.

This intentionally does not add a database or cross-restart persistence. Burp's `copyToTempFile()` provides snapshot lifetime for the running suite, while the registry stays bounded to 1,000 entries.

## Impact

Agents can reliably refer back to an exchange after its original source item disappears, while keeping large requests and responses out of default tool results.

## Validation

- `./gradlew test`
- 105 tests passed in the implementation run; final rerun completed successfully.
- Focused assertion-quality audit passed after strengthening snapshot-retention and Repeater negative-pair coverage.

Stacked on #116 (`agent/fix-tool-contracts`).
